### PR TITLE
CMR-10336: export CMR logs to S3

### DIFF
--- a/cmr_logs_categorizer/README.md
+++ b/cmr_logs_categorizer/README.md
@@ -1,0 +1,9 @@
+# CMR Logs Categorizer
+These scripts prepare and analyze logs of CMR queries in order to classify them into broad categories. These categories will be helpful in designing the future architecture of BiGSTAC, optimizing performance, and better understanding user needs.
+
+## `export_logs.sh`
+- Export logged CMR queries to S3 for a specified range of dates.
+
+The S3 bucket will need to have already been created before running this script, and it has been for CMR PROD. A policy was attached to the bucket to allow Cloudwatch to write to it. A template policy allowing this is in `cloudwatch_s3_policy.json`. It would need the placeholder ACCOUNT_NUMBER strings to be replaced with the actual AWS account number. That can be obtained with `aws sts get-caller-identity`.
+
+The script and the template policy file both assume the bucket name is `bigstac-cmr-prod-logs`, but an alternate name can be given to the script.

--- a/cmr_logs_categorizer/cloudwatch_s3_policy.json
+++ b/cmr_logs_categorizer/cloudwatch_s3_policy.json
@@ -1,0 +1,38 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "logs.us-east-1.amazonaws.com"
+            },
+            "Action": "s3:GetBucketAcl",
+            "Resource": "arn:aws:s3:::bigstac-cmr-prod-logs",
+            "Condition": {
+                "StringEquals": {
+                    "aws:SourceAccount": "ACCOUNT_NUMBER"
+                },
+                "ArnLike": {
+                    "aws:SourceArn": "arn:aws:logs:us-east-1:ACCOUNT_NUMBER:log-group:*"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "logs.us-east-1.amazonaws.com"
+            },
+            "Action": "s3:PutObject",
+            "Resource": "arn:aws:s3:::bigstac-cmr-prod-logs/*",
+            "Condition": {
+                "StringEquals": {
+                    "aws:SourceAccount": "ACCOUNT_NUMBER",
+                    "s3:x-amz-acl": "bucket-owner-full-control"
+                },
+                "ArnLike": {
+                    "aws:SourceArn": "arn:aws:logs:us-east-1:ACCOUNT_NUMBER:log-group:*"
+                }
+            }
+        }
+    ]
+}

--- a/cmr_logs_categorizer/export_logs.sh
+++ b/cmr_logs_categorizer/export_logs.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -e
+
+# Function to display usage
+show_usage() {
+    echo "This script exports CMR logs for the specified time range to a S3 bucket."
+    echo
+    echo "Ensure the dates are formatted according to the examples below."
+    echo "The dates are inclusive: StartDate begins at midnight, and the"
+    echo "EndDate ends at 11:59 PM."
+    echo
+    echo "Usage:   $0 StartDate EndDate"
+    echo "Example: $0 \"Oct 08 2024\" \"Oct 15 2024\""
+    echo
+    echo "Optionally provide the Cloudwatch log group name (default: cmr-search-prod)"
+    echo "AWS profile name (default: cmr-prod), AWS region (defualt us-east-1),"
+    echo "and destination bucket (default: bigstac-cmr-prod-logs):"
+    echo "Usage:   $0 StartDate EndDate LOG_GROUP_NAME AWS_PROFILE AWS_REGION S3_BUCKET"
+}
+
+# Check if no arguments were provided
+if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+    show_usage
+    exit 1
+fi
+
+# Check if the required arguments are provided
+if [ $# -lt 2 ]; then
+    echo "Error: Missing required date arguments." >&2
+    show_usage
+    exit 1
+fi
+
+startDate=$1
+endDate=$2
+endDate+=" 23:59:59"
+
+logGroupName=${3:-"cmr-search-prod"}
+awsProfile=${4:-"cmr-prod"}
+awsRegion=${5:-"us-east-1"}
+bucket=${6:-"bigstac-cmr-prod-logs"}
+
+# Calculate timestamp versions of dates, appending filler zeroes for milliseconds
+startStamp=$(date -j -f "%b %d %Y" "$startDate" +"%s")"000"
+endStamp=$(date -j -f "%b %d %Y %H:%M:%S" "$endDate" +"%s")"000"
+
+# Run export task
+taskID_JSON=$(aws --profile $awsProfile --region $awsRegion logs create-export-task --log-group-name $logGroupName --from $startStamp --to $endStamp --destination $bucket)
+taskID=$(jq '.taskId' <<< "$taskID_JSON" | tr -d '"')
+
+echo "Export task $taskID started."
+echo "When complete, the log data will be at:"
+echo "s3://$bucket/exportedlogs/$taskID/"
+echo
+echo "Check status of the export job with:"
+echo "aws --profile $awsProfile --region $awsRegion logs describe-export-tasks --task-id $taskID"

--- a/cmr_logs_categorizer/export_logs.sh
+++ b/cmr_logs_categorizer/export_logs.sh
@@ -3,7 +3,7 @@ set -e
 
 # Function to display usage
 show_usage() {
-    echo "This script exports CMR logs for the specified time range to a S3 bucket."
+    echo "This script exports CMR logs for the specified date range to a S3 bucket."
     echo
     echo "Ensure the dates are formatted according to the examples below."
     echo "The dates are inclusive: StartDate begins at midnight, and the"


### PR DESCRIPTION
This script exports CMR query logs to S3 for the specified time range. We use this to get the logs to analyze for query patterns for Bigstac planning.

Below is the help text printed by the script:

```
This script exports CMR logs for the specified time range to a S3 bucket.

Ensure the dates are formatted according to the examples below.
The dates are inclusive: StartDate begins at midnight, and the
EndDate ends at 11:59 PM.

Usage:   ./export_logs.sh StartDate EndDate
Example: ./export_logs.sh "Oct 08 2024" "Oct 15 2024"

Optionally provide the Cloudwatch log group name (default: cmr-search-prod)
AWS profile name (default: cmr-prod), AWS region (defualt us-east-1),
and destination bucket (default: bigstac-cmr-prod-logs):
Usage:   ./export_logs.sh StartDate EndDate LOG_GROUP_NAME AWS_PROFILE AWS_REGION S3_BUCKET
```