### PR TITLE
CMR-10352: Categorize CMR queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ __pycache__
 
 **/*.csv
 
+*.Rproj*
+

--- a/cmr_logs_categorizer/README.md
+++ b/cmr_logs_categorizer/README.md
@@ -7,3 +7,15 @@ These scripts prepare and analyze logs of CMR queries in order to classify them 
 The S3 bucket will need to have already been created before running this script, and it has been for CMR PROD. A policy was attached to the bucket to allow Cloudwatch to write to it. A template policy allowing this is in `cloudwatch_s3_policy.json`. It would need the placeholder ACCOUNT_NUMBER strings to be replaced with the actual AWS account number. That can be obtained with `aws sts get-caller-identity`.
 
 The script and the template policy file both assume the bucket name is `bigstac-cmr-prod-logs`, but an alternate name can be given to the script.
+
+## `batch_tables.sh`
+**(DRAFT)**
+
+`./batch_tables.sh list_of_parquet_files.txt NCPUS OPTIONAL_LIMIT`
+or
+`./batch_tables.sh directory_of_parquet_files NCPUS OPTIONAL_LIMIT`
+
+## `categorize queries.Rmd`
+**(DRAFT)**
+Work in progress. When complete, knit this document to produce a report.
+*May split this into one document to prepare data in DuckDB, and another to generate the report*

--- a/cmr_logs_categorizer/README.md
+++ b/cmr_logs_categorizer/README.md
@@ -1,21 +1,84 @@
 # CMR Logs Categorizer
 These scripts prepare and analyze logs of CMR queries in order to classify them into broad categories. These categories will be helpful in designing the future architecture of BiGSTAC, optimizing performance, and better understanding user needs.
 
-## `export_logs.sh`
+## 1. `export_logs.sh`
 - Export logged CMR queries to S3 for a specified range of dates.
+
+Example usage:
+```sh
+# export_logs.sh  StartDate     EndDate (inclusive)
+./export_logs.sh "Oct 01 2024" "Oct 07 2024"
+```
 
 The S3 bucket will need to have already been created before running this script, and it has been for CMR PROD. A policy was attached to the bucket to allow Cloudwatch to write to it. A template policy allowing this is in `cloudwatch_s3_policy.json`. It would need the placeholder ACCOUNT_NUMBER strings to be replaced with the actual AWS account number. That can be obtained with `aws sts get-caller-identity`.
 
 The script and the template policy file both assume the bucket name is `bigstac-cmr-prod-logs`, but an alternate name can be given to the script.
 
-## `batch_tables.sh`
-**(DRAFT)**
+The script will output the task ID for the export job. That will be the prefix that the logs will be exported to, as in:
 
-`./batch_tables.sh list_of_parquet_files.txt NCPUS OPTIONAL_LIMIT`
-or
-`./batch_tables.sh directory_of_parquet_files NCPUS OPTIONAL_LIMIT`
+`s3://bigstac-cmr-prod-logs/exportedlogs/taskID`
 
-## `categorize queries.Rmd`
-**(DRAFT)**
-Work in progress. When complete, knit this document to produce a report.
-*May split this into one document to prepare data in DuckDB, and another to generate the report*
+## 2. Download Logs
+
+Check if the export job is complete with
+```sh
+aws --profile $awsProfile --region $awsRegion logs describe-export-tasks --task-id $taskID
+```
+Using the task ID output by `export_logs.sh`.
+
+When the export job is complete, change to the directory you want them downloaded to, then download them with:
+
+```sh
+aws --profile $awsProfile s3 cp --recursive s3://bigstac-cmr-prod-logs/exportedlogs/$taskID/ .
+```
+
+## 3. `batch_tables.sh`
+- Extract selected information from compressed log files and write it to parquet files.
+
+Example usage:
+```sh
+# Use a list of .gz files to process
+./batch_tables.sh list_of_gz_files.txt NCPUS OPTIONAL_LIMIT
+# or search a directory and subdirectories for .gz files
+./batch_tables.sh exported_log_directory NCPUS OPTIONAL_LIMIT
+```
+The directory method is designed to work with the file organization downloaded from the export steps above.
+
+`NCPUS` is required. Expect each process to use 1-2 GB of RAM. I typically used 4 CPUs on a Macbook Pro 16 GB with some other programs open.
+
+`OPTIONAL_LIMIT` is a number limiting processing to the first N files. This can be used to verify this step works or that the value of `NCPUS` chosen is appropriate.
+
+## 4. `count_shapefiles.sh`
+- Count the number of times users uploaded a shapefile to CMR in each directory of log files.
+
+The REPORT type logs used in the `batch_tables.sh` workflow does not include any information about uploaded shapefiles. It does include spatial queries specified as coordinates to the CMR API, which are by far the majority of spatial queries. Indications of shapefile uploads have fewer details and are in different log events.
+
+Run `count_shapefiles.sh` once before running the Rmd report in the next step. Then the report will include the number of shapefile uploads, for which we don't have any details (like shape or size), and compare that count to the spatial queries we do have detailed information for.
+
+Example usage:
+```sh
+./count_shapefiles.sh exported_log_directory NCPUS
+```
+This is much less RAM-intensive, and I used 8 CPUs when I ran this step.
+
+This script outputs a `shapes` file in each directory containing the downloaded `.gz` logs. You can total these up with the `sum_shapes.sh` script if you'd like, which is the same script the report will use.
+
+## 5. `categorize queries.Rmd`
+- A report that collects the processed log data, categorizes queries, and creates several charts.
+
+First, install R if you haven't already.
+
+Start an R session and install the necessary packages:
+```r
+# Optional setting that can speed up package installs
+options(Ncpus=4)
+
+install.packages(c("data.table", "stringr", "sf", "arrow", "duckdb", "ggplot2", "rmarkdown"))
+```
+
+If you have installed the RStudio IDE, you can click the Knit button on the Rmd file to render it to a HTML file. Otherwise, open a R session from a terminal in this directory and run:
+```r
+rmarkdown::render('categorize_queries.Rmd')
+```
+
+The report starts by bringing the data from all the parquet files written by `batch_tables.sh` into a single DuckDB database file. The database should only be created and modified once, otherwise subsequent attempts to run the report will generate errors. Change the `modifyDB` value in the Rmd to `TRUE` if this is your first time running the report. See the guidance in the `About RMarkdown` section of the Rmd file for more information.

--- a/cmr_logs_categorizer/analysis_functions.R
+++ b/cmr_logs_categorizer/analysis_functions.R
@@ -53,7 +53,6 @@ wkt_area <- function(wkt_column, transform_crs = "EPSG:4326"){
 #'   the `threshold_above` value and 1.
 in_quantile <- function(data, threshold_above){
   if(threshold_above < 0 | threshold_above > 1) stop("threshold_above must be between 0 and 1")
-  probvec = c(0, threshold_above, 1)
-  quants = quantile(data, na.rm = TRUE, probs = probvec)
-  data >= quants[2] 
+  quants = quantile(data, na.rm = TRUE, probs = threshold_above)
+  data >= quants 
 }

--- a/cmr_logs_categorizer/analysis_functions.R
+++ b/cmr_logs_categorizer/analysis_functions.R
@@ -1,0 +1,59 @@
+
+#' Open a list of parquet tables and combine into a single data.table.
+#'
+#' @param file_paths character vector of paths to each parquet file.
+#'
+#' @returns a single data.table containing the rows of all of the parquet files.
+combine_parquet <- function(file_paths){
+  tables = lapply(file_paths, function(x){
+    read_parquet(x)
+  })
+  dt = rbindlist(tables, use.names = TRUE, fill = TRUE)
+  # Recalculate id column using the row indices for the new larger table
+  dt[, id := .I]
+}
+
+
+#' Counts the number of vertices in WKT strings
+#'
+#' @param wkt_column a column (list) of WKT strings of any geometry type
+#'
+#' @returns an integer vector containing vertex counts for every WKT string
+count_vertices <- function(wkt_column){
+  str_count(wkt_column, ",") + 1
+}
+
+
+#' Calcualte area for WKT geometries
+#'
+#' NA values should be removed before this function. 
+#' The coordinate reference system the WKT strings are recorded in is assumed to be WGS84 (EPSG:4326).
+#' 
+#' @param wkt_column a column (list) of WKT strings of any geometry type, although only POLYGON types will have non-zero area.
+#' @param transform_crs coordinate reference system to use for calculating area
+#'
+#' @returns a numeric vector of area calculations for each WKT string
+wkt_area <- function(wkt_column, transform_crs = "EPSG:4326"){
+  geom_column = st_as_sfc(wkt_column, crs = "EPSG:4326")
+  if(transform_crs != "EPSG:4326"){
+    geom_column = st_transform(geom_column, crs = transform_crs)
+  }
+  st_area(geom_column)
+}
+
+
+#' Determine membership in quantile
+#'
+#' @param data Numeric vector
+#' @param threshold_above A number between 0 and 1. Data values of data are
+#'   normalized from 0 to 1. Any normalized value above this provided threshold
+#'   is considered TRUE.
+#'
+#' @returns a logical vector indicating if the normalized data value is between
+#'   the `threshold_above` value and 1.
+in_quantile <- function(data, threshold_above){
+  if(threshold_above < 0 | threshold_above > 1) stop("threshold_above must be between 0 and 1")
+  probvec = c(0, threshold_above, 1)
+  quants = quantile(data, na.rm = TRUE, probs = probvec)
+  data >= quants[2] 
+}

--- a/cmr_logs_categorizer/batch_tables.sh
+++ b/cmr_logs_categorizer/batch_tables.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+set -e
+
+# Check if a directory argument is provided
+if [ $# -eq 0 ]; then
+    echo "Please provide a directory path as an argument."
+    exit 1
+fi
+
+# Check if at least two arguments are provided
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <directory_path> <num_threads> [file_limit]"
+    exit 1
+fi
+
+# Check if the provided argument is a valid directory
+if [ ! -d "$1" ]; then
+    echo "The provided path is not a valid directory."
+    exit 1
+fi
+
+# Check if GNU Parallel is installed
+if ! command -v parallel &> /dev/null; then
+    echo "GNU Parallel is not installed. Please install it to run this script."
+    exit 1
+fi
+
+# Set the number of threads
+num_threads=${2}
+
+# Check if a file limit was specified
+if [ $# -eq 3 ]; then
+    if [[ $3 =~ ^[0-9]+$ ]]; then
+        num_files=$3
+        echo "Will process the first $num_files files"
+    else
+        echo "Error: Third argument must either be a positive integer, or omitted to process all files."
+        exit 1
+    fi
+else
+    # 0 used as a code for all files
+    num_files=0
+fi
+
+process_logs() {
+  # Get the filename from the first argument
+  in_filename="$1"
+
+  # Extract the filename without extension
+  filename_no_ext="${in_filename%.*}"
+
+  # Output filename
+  json_filename="${filename_no_ext}.json"
+
+  # Get REPORT type log records
+  # Keep only the JSON portion of the records (within the {})
+  # Combine all of the JSON records into a single array
+  # Save it to a file
+  gzcat $in_filename | grep REPORT | grep -oE "\\{.*\\}" | jq -s '.' > $json_filename
+
+  # Run the RScript to extract desired keys from the JSON and write parquet tables
+  Rscript log_to_table.R $json_filename
+  
+  # Delete extracted JSON
+  rm $json_filename
+}
+
+# Export the function so it's available to GNU Parallel
+export -f process_logs
+
+# Use GNU Parallel to process all .gz files
+if [ $num_files -gt 0 ]; then
+  find $1 -type f -name "*.gz" | sort | head -n $num_files | parallel -j $num_threads process_logs
+else
+  find $1 -type f -name "*.gz" | sort | parallel -j $num_threads process_logs
+fi

--- a/cmr_logs_categorizer/categorize_queries.Rmd
+++ b/cmr_logs_categorizer/categorize_queries.Rmd
@@ -104,7 +104,7 @@ if(modifyDB) { dbExecute(con, paste(
 
 There are several attributes of CMR queries that we expect may be relevant to CMR query performance. These include whether the user included a spatial query, how complex the shape is, the presence of a temporal query, and the presence of specified sort order(s).
 
-First, calculate these indicator variables for all the queries in the sample. Then consider their joint presence/absense to group them into broad categories.
+First, calculate these indicator variables for all the queries in the sample. Then consider their joint presence/absence to group them into broad categories.
 
 ### Spatial boolean
 
@@ -122,7 +122,7 @@ if(modifyDB) {
 
 #### Uploaded Shapefiles
 
-We've only parsed spatial queries that were passed as coordiantes through CMR, but users can also upload shapefiles. While running in production, CMR does not log the details of these geometries. That means we can't determine their location, area, or vertex complexity after the fact.
+We've only parsed spatial queries that were passed as coordinates through CMR, but users can also upload shapefiles. While running in production, CMR does not log the details of these geometries. That means we can't determine their location, area, or vertex complexity after the fact.
 
 It's certainly possible that uploaded shapefiles differ in complexity from the geometries provided as coordinates to the CMR API. However, these represent a relatively small proportion of all spatial queries.
 
@@ -141,7 +141,7 @@ cat(paste(
   "spatial queries with coordinates were successfully parsed."))
 ```
 
-Because we don't have the coordiantes for these `r uploaded_shape_count` queries, they are not counted in the spatial boolean or spatial complexity variables.
+Because we don't have the coordinates for these `r uploaded_shape_count` queries, they are not counted in the spatial boolean or spatial complexity variables.
 
 ### Spatial complexity
 
@@ -514,7 +514,7 @@ The following categories in the logged CMR queries were not covered by the lates
 p_cats[!dtSuite8][order(p0.5)]
 ```
 
-But a large portion of these queries are easier than others: the ones in the `00000` category have none of the query paramaters we've selected as being interesting for performance. What proportion of the queries does the benchmark suite cover if we exclude this category with the fastest median processing time and the largest number of queries?
+But a large portion of these queries are easier than others: the ones in the `00000` category have none of the query parameters we've selected as being interesting for performance. What proportion of the queries does the benchmark suite cover if we exclude this category with the fastest median processing time and the largest number of queries?
 
 ```{r coverage2}
 paste("The latest benchmark suite would cover",

--- a/cmr_logs_categorizer/categorize_queries.Rmd
+++ b/cmr_logs_categorizer/categorize_queries.Rmd
@@ -96,6 +96,14 @@ granule_queries = dbGetQuery(
 cat(paste("Granule queries:", format(granule_queries, big.mark=",")))
 ```
 
+Check time range of the processed logs
+
+```{r time_range, results='hold'}
+cat(paste("First query:", dbGetQuery(con, 'SELECT min(now) FROM week1'), '\n'))
+cat(paste("Last query: ", dbGetQuery(con, 'SELECT max(now) FROM week1')))
+```
+
+
 ### Example rows
 
 ```{r example_rows}

--- a/cmr_logs_categorizer/categorize_queries.Rmd
+++ b/cmr_logs_categorizer/categorize_queries.Rmd
@@ -110,6 +110,29 @@ if(modifyDB) {
 }
 ```
 
+#### Uploaded Shapefiles
+
+We've only parsed spatial queries that were passed as coordiantes through CMR, but users can also upload shapefiles. While running in production, CMR does not log the details of these geometries. That means we can't determine their location, area, or vertex complexity after the fact.
+
+It's certainly possible that uploaded shapefiles differ in complexity from the geometries provided as coordinates to the CMR API. However, these represent a relatively small proportion of all spatial queries.
+
+Running the `count_shapefiles.sh` script finds log entries that indicate a shapefile was uploaded, and then `sum_shapes.sh` will total these up. The following compares the count of spatial queries using uploaded shapefiles vs. those providing coordinates directly to the CMR API:
+
+```{r sum_shapes, results='hold'}
+uploaded_shape_count = system2(
+  "./sum_shapes.sh", log_export_directory, stdout = TRUE)
+parsed_wkt_count = dbGetQuery(
+  con, "SELECT COUNT(*) FROM week1 WHERE spatial_bool = TRUE")
+cat(paste(
+  format(uploaded_shape_count, big.mark=','), 
+  "shapes were uploaded to CMR for which we do not have coordinates.\n"))
+cat(paste(
+  format(parsed_wkt_count, big.mark=','), 
+  "spatial queries with coordinates were successfully parsed."))
+```
+
+Because we don't have the coordiantes for these `r uploaded_shape_count` queries, they are not counted in the spatial boolean or spatial complexity variables.
+
 ### Spatial complexity
 
 #### Vertex Count
@@ -470,10 +493,6 @@ dtSuite8
 ```
 
 The California shape we used in benchmarks was 99th percentile complex in terms of both vertex count and area (categories codes ending in `11`). That combination was not seen in any of the 18 million granule queries in the week of data we've analyzed here, which is why those two categories have NA values in the join result below.
-
-However, we've only parsed the logs that exist in Cloudwatch. Uploaded shapefiles are only logged when CMR is running in debug mode, not in production. It's certainly possible that uploaded shapefiles tend to be more complex than ones that are drawn in Earthdata Search or provided as well-known text. Uploaded files are a very small proportion of total spatial queries, however.
-
-**TODO**: calculate proportion in the document
 
 ```{r benchmark_categories_log_summary}
 setkey(p_cats, "test_cat")

--- a/cmr_logs_categorizer/categorize_queries.Rmd
+++ b/cmr_logs_categorizer/categorize_queries.Rmd
@@ -23,15 +23,29 @@ suppressPackageStartupMessages({
 source('analysis_functions.R')
 ```
 
+## About RMarkdown
+
+RMarkdown is like a Jupyter notebook, in that there are code cells, whose output can be printed right below them, and these can be intermixed blocks of markdown-formatted text.
+
+Within the RStudio IDE, you can see the output of code cells when you run them, but cell output is not saved to the `.Rmd` file. Jupyter notebooks, however, include common kinds of cell output (e.g. images, tables) within the saved `.ipynb` file.
+
+This means that while code and documentation is written and debugged within a `.Rmd` file, when you're ready to share analysis results with others, you typically render the document to a common publication format like HTML or PDF. The intended format is set in the YAML block at the top of the file. Rendering the document is also called "knitting" it, since it uses the `knitr` package.
+
+This notebook gathers and prepares data, and includes some database operations (like creating a new column) that should only be run once. Because the knitting process runs all the code blocks (which helps ensure that the results are reproducible!), it might fail on an error when encountering operations that shouldn't be run again. In the interest of both showing the complete workflow and avoiding more verbose logic that checks the database status before every operation, I'm creating this simple boolean below that indicates whether to modify the database.
+
+If this is the first time you've tun this code, or you've changed the database path above this block to point to a new file, you can set it to `TRUE`.
 
 ```{r connect}
 con <- dbConnect(duckdb(), dbdir = "../dev/log_parsing/logs_week1.db")
-# dbExecute(con, "SET enable_object_cache=true")
+```
+```{r modifyDB}
+modifyDB = FALSE
 ```
 
 ## Load parquet into DuckDB DB
 
 Prepare column names
+
 ```{r column_names, results='hide'}
 dtExample = dbGetQuery(con, "SELECT * FROM read_parquet('../dev/log_parsing/logs/**/*.parquet', union_by_name=true) LIMIT 1")
 column_names = names(dtExample)
@@ -40,51 +54,66 @@ columns_except_id = paste(setdiff(column_names, "id"), collapse = ", ") # remove
 ```
 
 Load parquet data into database file
+
 ```{r create_db, results='hide'}
-dbExecute(con, paste(
+if(modifyDB) { dbExecute(con, paste(
   'CREATE OR REPLACE TABLE week1 AS FROM (SELECT', 
   columns_except_id,
   'FROM read_parquet("../dev/log_parsing/logs/**/*.parquet", union_by_name=true)',
-  'ORDER BY now)'))
+  'ORDER BY now)')) }
 ```
 
 Check row count of created table
+
 ```{r check_row_count}
 format(dbGetQuery(con, "SELECT COUNT(*) FROM week1")[1,1], big.mark=",")
 ```
 
 ### Example rows
-```{r}
+
+```{r example_rows}
 dbGetQuery(con, "SELECT * FROM week1 LIMIT 10")
 ```
 
 Recalculate row ID column
+
 ```{r rowID, results='hide'}
-dbExecute(con, paste(
+if(modifyDB) { dbExecute(con, paste(
   "CREATE SEQUENCE id_seq START 1;",
   "ALTER TABLE week1 ADD COLUMN id INTEGER DEFAULT nextval('id_seq');"
-))
+))}
 ```
 
-## Spatial boolean
+## Categorize CMR Queries
+
+There are several attributes of CMR queries that we expect may be relevant to CMR query performance. These include whether the user included a spatial query, how complex the shape is, the presence of a temporal query, and the presence of specified sort order(s).
+
+First, calculate these indicator variables for all the queries in the sample. Then consider their joint presence/absense to group them into broad categories.
+
+### Spatial boolean
+
 ```{r wkt_null_counts, include=FALSE}
-dbGetQuery(con, "SELECT COUNT(*) FROM week1 WHERE wkt IS NULL")
-dbGetQuery(con, "SELECT COUNT(*) FROM week1 WHERE wkt IS NOT NULL")
+# An unfortunate requirement to print some data frames as HTML tables when knitting the document is enclosing them in parenthesis. Otherwise wrapping with parentheses isn't required.
+(dbGetQuery(con, "SELECT COUNT(*) FROM week1 WHERE wkt IS NULL"))
+(dbGetQuery(con, "SELECT COUNT(*) FROM week1 WHERE wkt IS NOT NULL"))
 ```
 
 ```{r spatial_bool, results='hide'}
-dbExecute(con, paste( 
-          "ALTER TABLE week1",
-          "ADD COLUMN spatial_bool BOOLEAN DEFAULT FALSE"))
-dbExecute(con, paste( 
-          "UPDATE week1",
-          "SET spatial_bool = TRUE",
-          "WHERE wkt IS NOT NULL"))
+if(modifyDB) { 
+  dbExecute(con, paste( 
+            "ALTER TABLE week1",
+            "ADD COLUMN spatial_bool BOOLEAN DEFAULT FALSE"))
+  dbExecute(con, paste( 
+            "UPDATE week1",
+            "SET spatial_bool = TRUE",
+            "WHERE wkt IS NOT NULL"))
+}
 ```
 
-## Spatial complexity
+### Spatial complexity
 
-### Vertex Count
+#### Vertex Count
+
 ```{r vertex_count}
 dtWKT = dbGetQuery(con, "SELECT wkt, id, geo_type FROM week1")
 setDT(dtWKT)
@@ -94,45 +123,46 @@ dtWKT[!is.na(vertex_count), vertex_pctile := round(ecdf_fn_vert_count(vertex_cou
 dtWKT[!is.na(vertex_count), .N, by = .(vertex_count, vertex_pctile)][order(vertex_count)]
 ```
 
-### Area
+#### Area
+
 ```{r duckdb_spatial, include=FALSE}
 dbExecute(con, "INSTALL spatial; LOAD spatial")
 ```
 
 ```{r polygon_area, results='hide'}
-dbExecute(con, paste( 
+if(modifyDB) { dbExecute(con, paste( 
           "ALTER TABLE week1",
-          "ADD COLUMN polygon_area BIGINT"))
+          "ADD COLUMN polygon_area BIGINT"))}
 ```
 
 ```{r duckdb_area, results='hide'}
-dbExecute(con, paste( 
+if(modifyDB) { dbExecute(con, paste( 
           "UPDATE week1",
           "SET polygon_area = ST_AREA(ST_GeomFromText(wkt))",
-          "WHERE wkt IS NOT NULL AND geo_type == 'POLYGON'"))
+          "WHERE wkt IS NOT NULL AND geo_type == 'POLYGON'"))}
 ```
 
-```{r}
-dbGetQuery(con, "SELECT MAX(polygon_area) FROM week1 WHERE polygon_area IS NOT NULL")
+```{r dtAreas}
 dtAreas = dbGetQuery(con, "SELECT id, polygon_area FROM week1 WHERE polygon_area IS NOT NULL")
 setDT(dtAreas)
 ```
 
-```{r}
+```{r ecdf_area}
 ecdf_fn_area <- ecdf(dtAreas$polygon_area)
 dtAreas[!is.na(polygon_area), area_pctile := ecdf_fn_area(polygon_area), by = .(polygon_area)]
 dtAreas[!is.na(polygon_area), .N, by = .(polygon_area, area_pctile)][order(polygon_area)]
 ```
 
-### Join Vertex Count and Area back to DuckDB table
+#### Join Vertex Count and Area back to DuckDB table
+
 ```{r add_area_vertex_columns, results='hide'}
-dbExecute(con, paste( 
+if(modifyDB) { dbExecute(con, paste( 
           "ALTER TABLE week1",
           "ADD COLUMN vertex_count USMALLINT;",
           "ALTER TABLE week1",
           "ADD COLUMN vertex_pctile FLOAT;",
           "ALTER TABLE week1",
-          "ADD COLUMN area_pctile FLOAT;"))
+          "ADD COLUMN area_pctile FLOAT;"))}
 ```
 
 ```{r register_areas_vertices, results='hide'}
@@ -140,7 +170,8 @@ duckdb_register(con, "dtAreas", dtAreas)
 duckdb_register(con, "dtWKT", dtWKT)
 ```
 
-```{r test_join, include=FALSE}
+```{r test_join, include=FALSE, eval=FALSE}
+# Testing if the join from an R data frame to DuckDB works
 dbGetQuery(con, paste(
   "SELECT week1.id, week1.polygon_area, dtAreas.area_pctile",
   "FROM week1",
@@ -148,16 +179,18 @@ dbGetQuery(con, paste(
   "ON week1.id = dtAreas.id"
 ))
 ```
+
 ```{r copy_area_pctile, results='hide'}
-dbExecute(con, paste(
+if(modifyDB) { dbExecute(con, paste(
   "UPDATE week1",
   "SET area_pctile = dtAreas.area_pctile",
   "FROM dtAreas",
   "WHERE week1.id = dtAreas.id"
-))
+))}
 ```
 
-```{r test_copied_area_pctile, include=FALSE}
+```{r test_copied_area_pctile, include=FALSE, eval=FALSE}
+# Test that polygon area data was copied from R to DuckDB
 dbGetQuery(con, paste(
   "SELECT id, polygon_area, area_pctile",
   "FROM week1",
@@ -169,17 +202,19 @@ dbGetQuery(con, paste(
   "WHERE area_pctile >= 0.99"
 ))
 ```
+
 ```{r copy_vertices, results='hide'}
-dbExecute(con, paste(
+if(modifyDB) { dbExecute(con, paste(
   "UPDATE week1",
   "SET vertex_count = dtWKT.vertex_count,",
       "vertex_pctile = dtWKT.vertex_pctile",
   "FROM dtWKT",
   "WHERE week1.id = dtWKT.id"
-))
+))}
 ```
 
-```{r test_copied_vertices, include=FALSE}
+```{r test_copied_vertices, include=FALSE, eval=FALSE}
+# Test that vertex counts were copied from R to DuckDB
 dbGetQuery(con, paste(
   "SELECT id, vertex_count, vertex_pctile",
   "FROM week1",
@@ -187,31 +222,42 @@ dbGetQuery(con, paste(
 ))
 ```
 
-## Temporal Boolean
+```{r rm_dtWKT}
+# Keep a copy of the vertices for later
+dtVert = dtWKT[!is.na(vertex_count), .(vertex_count)]
+# Recover some memory in R
+rm(dtWKT)
+```
+
+### Temporal Boolean
 
 ```{r temporal_bool, include=FALSE}
-dbExecute(con, paste( 
-          "ALTER TABLE week1",
-          "ADD COLUMN temporal_bool BOOLEAN DEFAULT FALSE"))
-dbExecute(con, paste( 
-          "UPDATE week1",
-          "SET temporal_bool = TRUE",
-          "WHERE time_query IS NOT NULL"))
+if(modifyDB) { 
+  dbExecute(con, paste( 
+            "ALTER TABLE week1",
+            "ADD COLUMN temporal_bool BOOLEAN DEFAULT FALSE"))
+  dbExecute(con, paste( 
+            "UPDATE week1",
+            "SET temporal_bool = TRUE",
+            "WHERE time_query IS NOT NULL"))
+}
 ```
 
-## Ordering Boolean
+### Ordering Boolean
 
 ```{r sort_bool, results='hide'}
-dbExecute(con, paste( 
-          "ALTER TABLE week1",
-          "ADD COLUMN sort_bool BOOLEAN DEFAULT FALSE"))
-dbExecute(con, paste( 
-          "UPDATE week1",
-          "SET sort_bool = TRUE",
-          "WHERE sort_key IS NOT NULL"))
+if(modifyDB) { 
+  dbExecute(con, paste( 
+            "ALTER TABLE week1",
+            "ADD COLUMN sort_bool BOOLEAN DEFAULT FALSE"))
+  dbExecute(con, paste( 
+            "UPDATE week1",
+            "SET sort_bool = TRUE",
+            "WHERE sort_key IS NOT NULL"))
+}
 ```
 
-### Multiple ordering
+#### Multiple ordering
 
 ```{r calculate_sort_count}
 dtOrders = dbGetQuery(con, "SELECT id, sort_key FROM week1 WHERE sort_key IS NOT NULL")
@@ -222,17 +268,20 @@ dtOrders[, .N, by = sort_count][order(-N)]
 
 ```{r copy_sort_count, results='hide'}
 duckdb_register(con, "dtOrders", dtOrders)
-dbExecute(con, paste( 
-          "ALTER TABLE week1",
-          "ADD COLUMN sort_count TINYINT"))
-dbExecute(con, paste( 
-          "UPDATE week1",
-          "SET sort_count = dtOrders.sort_count",
-          "FROM dtOrders",
-          "WHERE week1.id = dtOrders.id"))
+if(modifyDB) { 
+  dbExecute(con, paste( 
+            "ALTER TABLE week1",
+            "ADD COLUMN sort_count TINYINT"))
+  dbExecute(con, paste( 
+            "UPDATE week1",
+            "SET sort_count = dtOrders.sort_count",
+            "FROM dtOrders",
+            "WHERE week1.id = dtOrders.id"))
+}
 ```
 
-```{r test_sort_count, include=FALSE}
+```{r test_sort_count, include=FALSE, eval=FALSE}
+# Test that the sort count was copied from R to DuckDB
 dbGetQuery(con, paste(
   "SELECT id, sort_count",
   "FROM week1",
@@ -240,104 +289,171 @@ dbGetQuery(con, paste(
 ))
 ```
 
-## Provider vs. Collection
+### Provider vs. Collection
 
 ```{r create_prov_coll, results='hide'}
-dbExecute(con, paste( 
+if(modifyDB) { dbExecute(con, paste( 
           "ALTER TABLE week1",
-          "ADD COLUMN prov_coll CHARACTER DEFAULT ''"))
+          "ADD COLUMN prov_coll CHARACTER DEFAULT ''"))}
 ```
 
 ```{r update_prov_coll, results='hide'}
-dbExecute(con, paste( 
-          "UPDATE week1",
-          "SET prov_coll = 'Provider'",
-          "WHERE provider IS NOT NULL AND concept_id IS NULL")) # 7393219
-dbExecute(con, paste( 
-          "UPDATE week1",
-          "SET prov_coll = 'Collection'",
-          "WHERE provider IS NULL AND concept_id IS NOT NULL")) # 2651164
-dbExecute(con, paste( 
-          "UPDATE week1",
-          "SET prov_coll = 'Both'",
-          "WHERE provider IS NOT NULL AND concept_id IS NOT NULL")) # 4552353
+if(modifyDB) { 
+  dbExecute(con, paste( 
+            "UPDATE week1",
+            "SET prov_coll = 'Provider'",
+            "WHERE provider IS NOT NULL AND concept_id IS NULL")) # 7393219
+  dbExecute(con, paste( 
+            "UPDATE week1",
+            "SET prov_coll = 'Collection'",
+            "WHERE provider IS NULL AND concept_id IS NOT NULL")) # 2651164
+  dbExecute(con, paste( 
+            "UPDATE week1",
+            "SET prov_coll = 'Both'",
+            "WHERE provider IS NOT NULL AND concept_id IS NOT NULL")) # 4552353
+}
 ```
 
 ## Category Creation
 
 Set NA values for Area and Vertex percentiles to 0
+
 ```{r null_zero_percentiles, results='hide'}
-dbExecute(con, paste(
-  "UPDATE week1",
-  "SET area_pctile = 0",
-  "WHERE area_pctile IS NULL"
-))
-dbExecute(con, paste(
-  "UPDATE week1",
-  "SET vertex_pctile = 0",
-  "WHERE vertex_pctile IS NULL"
-))
+if(modifyDB) { 
+  dbExecute(con, paste(
+    "UPDATE week1",
+    "SET area_pctile = 0",
+    "WHERE area_pctile IS NULL"
+  ))
+  dbExecute(con, paste(
+    "UPDATE week1",
+    "SET vertex_pctile = 0",
+    "WHERE vertex_pctile IS NULL"
+  ))
+}
 ```
 
-```{r}
-dbExecute(con, paste(
-  "CREATE OR REPLACE VIEW cat1 AS FROM",
-  "(SELECT id, spatial_bool::UTINYINT || temporal_bool::UTINYINT || sort_bool::UTINYINT || (area_pctile>0.99)::UTINYINT || (vertex_pctile>0.99)::UTINYINT AS test_cat,",
-  "spatial_bool, temporal_bool, sort_bool, sort_count, polygon_area, vertex_count, cmr_took, prov_coll",
-  "FROM week1",
-  "WHERE concept == 'granules')"
-))
+```{r create_cat1}
+if(modifyDB) { 
+  dbExecute(con, paste(
+    "CREATE OR REPLACE VIEW cat1 AS FROM",
+    "(SELECT id, spatial_bool::UTINYINT || temporal_bool::UTINYINT || sort_bool::UTINYINT || (area_pctile>0.99)::UTINYINT || (vertex_pctile>0.99)::UTINYINT AS test_cat,",
+    "spatial_bool, temporal_bool, sort_bool, sort_count, polygon_area, vertex_count, cmr_took, prov_coll",
+    "FROM week1",
+    "WHERE concept == 'granules')"
+  ))
+}
 ```
 
 ### Category Summaries
 
 Example query rows with categorization
-```{r}
-dbGetQuery(con, "SELECT test_cat, spatial_bool, temporal_bool, sort_bool, sort_count, polygon_area, vertex_count, cmr_took FROM cat1 ORDER BY cmr_took DESC LIMIT 1000")
-```
-```{r time_by_cat_old, include=FALSE}
-time_by_cat = dbGetQuery(con, "SELECT test_cat, COUNT(*) AS count, AVG(cmr_took) AS mean_cmr_took FROM cat1 GROUP BY test_cat ORDER BY mean_cmr_took")
-setDT(time_by_cat)
-time_by_cat
+
+```{r example_queries_with_categories}
+(dbGetQuery(con, "SELECT test_cat, cmr_took, spatial_bool, temporal_bool, sort_bool, sort_count, polygon_area, vertex_count FROM cat1 ORDER BY cmr_took DESC LIMIT 100"))
 ```
 
-Summarize query time by category
-```{r time_by_cat}
-time_by_cat = dbGetQuery(con, paste(
-  "SELECT test_cat,",
-  "COUNT(*) AS count, AVG(cmr_took) AS mean_cmr_took,",
-  "substring(test_cat,1,1)::LOGICAL AS Spatial,",
-  "substring(test_cat,2,1)::LOGICAL AS Temporal,",
-  "substring(test_cat,3,1)::LOGICAL AS Sort,",
-  "substring(test_cat,4,1)::LOGICAL AS Area99,",
-  "substring(test_cat,5,1)::LOGICAL AS Vertex99",
-  "FROM cat1 GROUP BY test_cat ORDER BY mean_cmr_took"))
-setDT(time_by_cat)
-time_by_cat
+Around 3% of rows in this period are missing `cmr-took`. In the future, it may be worthwhile to fill those values with `duration` when it is available (not currently extracted into parquet files by `log_to_table.R`). The two values tend to be very similar.
+
+```{r dtCatTime}
+dtCatTime = dbGetQuery(con, "SELECT test_cat, cmr_took FROM cat1")
+setDT(dtCatTime)
+dtCatTime = dtCatTime[!is.na(cmr_took)] # 97% of granule query REPORTs include `cmr_took`
+setkey(dtCatTime, "test_cat")
 ```
 
-Take a look at 10110's provider/collection ratio
-- spatial, sort, 99th percentile area
-```{r}
-dbGetQuery(con, "SELECT COUNT(*) AS count, prov_coll, AVG(cmr_took) AS mean_cmr_took FROM cat1 WHERE test_cat == '10110' GROUP BY prov_coll")
+### CMR processing time percentiles
+
+```{r cmr_percentile, rows.print=16}
+unique_cats = dtCatTime[, unique(test_cat)]
+cmr_percentile <- function(unique_cats, percentile){
+  cat_perc = sapply(unique_cats, function(x){
+    quantile(dtCatTime[test_cat == x, cmr_took], probs = percentile)
+  })
+  names(cat_perc) <- unique_cats
+  dt = stack(cat_perc)
+  setDT(dt)
+  setnames(dt, old = c('values', 'ind'), new = c(paste0("p", percentile), "test_cat"))
+  setkey(dt, "test_cat")
+}
+p50_cats = cmr_percentile(unique_cats, 0.5)
+p95_cats = cmr_percentile(unique_cats, 0.95)
+
+# Calculate count of queries per category
+counts_cats = dtCatTime[, .(count = .N), by = test_cat]
+
+p_cats = p50_cats[p95_cats][counts_cats]
 ```
+
+Add columns explaining the binary coded category values
+
+```{r percentile_by_category}
+p_cats = p_cats[, .(test_cat, count, p0.5, p0.95, 
+  Spatial = as.logical(as.integer(str_sub(test_cat,1,1))),
+  Temporal = as.logical(as.integer(str_sub(test_cat,2,2))),
+  Sort = as.logical(as.integer(str_sub(test_cat,3,3))),
+  Area99 = as.logical(as.integer(str_sub(test_cat,4,4))),
+  Vertex99 = as.logical(as.integer(str_sub(test_cat,5,5)))
+)]
+```
+
+Display sorted by the most common query categories, descending
+
+```{r categories_by_count}
+p_cats[order(-count)]
+```
+
+Display sorted by the slowest categories (by 95th percentile), descending
+
+```{r categories_by_slowest}
+p_cats[order(-p0.95)]
+```
+
+#### Examine the provider/collection ratio for the slowest category
+
+Does searching by provider possibly explain some of the poor performance of the slowest categories?
+
+`10110` only has 25 rows, so there's not enough data to calculate 95th percentile CMR time by group. We'll use mean and median (50th percentile) for this check.
+
+```{r provider_10110}
+dbGetQuery(con, "SELECT COUNT(*) AS count, prov_coll, AVG(cmr_took) AS mean_cmr_took, MEDIAN(cmr_took) AS 'p0.5' FROM cat1 WHERE test_cat == '10110' GROUP BY prov_coll")
+```
+
+Mean and median are definitely sending different messages. Since this category only has 25 queries, take a look at the information we used to categorize them:
+
+```{r queries_10110}
+dbGetQuery(con, "SELECT test_cat, sort_count, polygon_area, vertex_count, cmr_took, prov_coll FROM cat1 WHERE test_cat == '10110' ORDER BY prov_coll, cmr_took DESC")
+```
+
+The slowest queries do use Providers, but there are proportionally plenty of fast examples, too. We'd have to check which providers they searched and which sorts were requested to get better insight into what made these searches slow. We're not doing that right now; this is just a small enough example to show within the notebook.
+
 ### Current test suite coverage
 
-Check percentile of the vertex count and area of CA shape used in benchmark suite
+In the Bigstac work thus far, we've used a suite of queries ([suite8.json](https://github.com/nasa/bigstac/blob/main/tester/suite8.json)) as a benchmarking tool to test various options in parquet format, file organization, compute resources, and DuckDB. If we assign those queries the same categories as we assigned to the logged CMR queries above, and then we can estimate how good our benchmark suite's coverage was of actual CMR usage.
 
-```{r}
+Our benchmark suite used two spatial features: a polygon of California (a simplified version of the shape from [Natural Earth](https://www.naturalearthdata.com/)), and a polygon representing the bounding box of California. To categorize the benchmark queries using these polygons, we'll need to calculate how its vertex count and polygon area rank among the logged queries in terms of percentile.
+
+Check percentile of the vertex count and area of CA shape used in benchmark suite:
+
+```{r ca_percentiles, results='hold'}
 paste("CA shape vertex percentile:", ecdf_fn_vert_count(426)) # 0.9998834
 ca_wkt = readLines("tmp_ca_verts")
 ca_shp = st_as_sfc(ca_wkt, crs = "EPSG:4326")
-#st_area(ca_shp) # 410506579297 [m^2]
-suppressMessages(sf_use_s2(FALSE))
+#st_area(ca_shp) # 410506579297 [m^2] using S2 (spherical)
+
+# The area calculations in DuckDB used the GEOS library, which is what SF will
+# use if we disable S2.
+suppressMessages(sf_use_s2(FALSE)) 
 ca_area = st_area(ca_shp)
-paste("CA shape area percentile:  ", ecdf_fn_area(ca_area)) # 410680461757 [m^2]
+paste("CA shape area percentile:  ", ecdf_fn_area(ca_area)) # 410680461757 [m^2] using GEOS (planar)
 ca_bbox_area = st_area(st_as_sfc("POLYGON ((-124.409202 32.531669, -114.119061 32.531669, -114.119061 41.99954, -124.409202 41.99954, -124.409202 32.531669))", crs = "EPSG:4326"))
 paste("CA BBOX area percentile:   ", ecdf_fn_area(ca_bbox_area))
 suppressMessages(sf_use_s2(TRUE))
 ```
-spatial_bool, temporal_bool, sort_bool, polygon_area, vertex_count
+
+For reference, the binary category variable order is:\
+`spatial_bool`, `temporal_bool`, `sort_bool`, `polygon_area`, `vertex_count`
+
 ```{r categorized_benchmark_suite}
 bigstac_suite8 = c(
   BBOX_time_sort_largeArea = "11110",
@@ -352,111 +468,310 @@ setDT(dtSuite8)
 setnames(dtSuite8, new = c("test_cat", "test_type"))
 dtSuite8
 ```
-Note that we tested with a shape that is both very complex in vertices and very large area - a combination that was not seen in the query data.
+
+The California shape we used in benchmarks was 99th percentile complex in terms of both vertex count and area (categories codes ending in `11`). That combination was not seen in any of the 18 million granule queries in the week of data we've analyzed here, which is why those two categories have NA values in the join result below.
+
+However, we've only parsed the logs that exist in Cloudwatch. Uploaded shapefiles are only logged when CMR is running in debug mode, not in production. It's certainly possible that uploaded shapefiles tend to be more complex than ones that are drawn in Earthdata Search or provided as well-known text. Uploaded files are a very small proportion of total spatial queries, however.
+
+**TODO**: calculate proportion in the document
+
 ```{r benchmark_categories_log_summary}
-setkey(time_by_cat, "test_cat")
+setkey(p_cats, "test_cat")
 setkey(dtSuite8, "test_cat")
-time_by_cat[dtSuite8, .(test_cat, count, mean_cmr_took, test_type)]
+p_cats[dtSuite8, ]
 ```
+
 ```{r coverage1}
 paste("The latest benchmark suite would cover",
-      scales::label_percent()(time_by_cat[dtSuite8, sum(count, na.rm = TRUE)]/time_by_cat[, sum(count)]),
+      scales::label_percent()(
+        dtCatTime[dtSuite8, .N]/dtCatTime[, .N]),
       "of queries")
 ```
 
+The following categories in the logged CMR queries were not covered by the latest benchmark suite:
 
-```{r non_covered_classes}
-non_covered_classes = time_by_cat[!dtSuite8][order(mean_cmr_took)]
-non_covered_classes
+```{r non_covered_classes_median}
+p_cats[!dtSuite8][order(p0.5)]
 ```
 
-But a large portion of the queries are trivial - ones with zero or few parameters that return quickly.
-What proportion of the queries does the benchmark suite cover if we exclude the two classes with the fastest processing time and large number of queries? "10000" and "00000"
+But a large portion of these queries are easier than others: the ones in the `00000` category have none of the query paramaters we've selected as being interesting for performance. What proportion of the queries does the benchmark suite cover if we exclude this category with the fastest median processing time and the largest number of queries?
+
 ```{r coverage2}
 paste("The latest benchmark suite would cover",
-      scales::label_percent()(time_by_cat[dtSuite8, sum(count, na.rm = TRUE)]/
-                                time_by_cat[!test_cat %in% c("00000", "10000"), sum(count)]),
+      scales::label_percent()(dtCatTime[dtSuite8, .N]/
+                                dtCatTime[!test_cat %in% c("00000"), .N]),
       "of non-trivial queries")
 ```
 
-### Categories of Interest
+However, we wouldn't want to exclude this category from consideration during the design of Bigstac, given that it represents a plurality of queries. There is also significant variation within this category, as seen by the 1.3s difference between the 50th and 95th percentile performance. Possible routes for explanation of that variance would be looking at variables not included in the categories, like requested page size, or calculating a measurement of CMR load using a window function to count the number of queries received in the surrounding X minutes. Other possible explanations would not be in the `cmr-logs` log group, like load introduced by data ingestion.
 
-We have 16 categories in this one week sample of CMR queries. For common categories, look at their probability distributions for CMR processing time.
+## Selecting Categories of Interest
 
-Below is a table of the most common categories. 
+We have 16 categories in this one week sample of CMR queries. Below is a table of the most common categories.
 
 ```{r most_common_categories}
-time_by_cat[order(-count)]
+p_cats[order(-count)]
 ```
 
-We will use the top 6 categories, which each have over 1 million queries.
+We need to keep in mind some existing realistic query patterns when designing Bigstac. If we were to focus on the top 6 most common categories, they would represent 98.5% of the queries.
 
-```{r}
-cat6 = time_by_cat[order(-count)][1:6, test_cat]
+```{r top_six_cats_percentage}
+p_cats[order(-count)][1:6, sum(count)]/p_cats[, sum(count)]
+```
+
+```{r top_size_cats}
+cat6 = p_cats[order(-count)][1:6, test_cat]
 cat6
 ```
 
 Which of these are in the current benchmark suite?
-```{r}
+
+```{r top_six_in_suite}
 dtSuite8[test_cat %in% cat6]
 ```
 
 Which categories in the benchmark suite are not in the top 6 most common categories?
-```{r}
+
+```{r suite_not_in_top_six}
 dtSuite8[!test_cat %in% cat6]
 ```
 
-```{r}
-time_by_cat[test_cat %in% cat6]
-time_by_cat[test_cat %in% dtSuite8$test_cat]
+Top 6 categories
+
+```{r top6_cats}
+p_cats[test_cat %in% cat6]
+```
+
+Below are the 4 categories from the benchmark suite that exist in the log data. Note the two most common below are also in the top 6 set above. The other two are quite rare in the log data.
+
+```{r suite_cats}
+p_cats[test_cat %in% dtSuite8$test_cat]
 ```
 
 ### Density of CMR time by query categories
-```{r}
-dtCatTime = dbGetQuery(con, "SELECT test_cat, cmr_took FROM cat1")
-setDT(dtCatTime)
-dtCatTime = dtCatTime[!is.na(cmr_took)] # 97% of granule query REPORTs include `cmr_took`
-setkey(dtCatTime, "test_cat")
-```
 
-```{r}
+```{r cmr_time_density_setup}
 dtCatTimeSub = dtCatTime[test_cat %in% cat6]
 dtCatTimeSub[, test_cat := as.factor(test_cat)]
 p_dens_cats <- ggplot(dtCatTimeSub, aes(cmr_took, color = test_cat, fill = test_cat))+
   geom_density(alpha = 0.06) +
-  xlim(c(0,2500)) + 
+  xlim(c(0,2500)) + # limiting this range is what generates the warning in the plot
   labs(color='Category', fill = 'Category') +
-  guides(color = guide_legend(position = "inside"))
+  guides(color = guide_legend(position = "inside")) + 
+  theme(legend.position.inside = c(0.93, 0.75))
+p_dens_cats
 ```
-```{r}
-p_dens_cats + theme(legend.position.inside = c(0.93, 0.75))
-```
-
-
 
 ## Other Analysis
 
-```{r}
-col.par = function(n) sample(seq(0.3, 1, length.out=50),n)
-```
-
 ### Concept Types
 
-```{r bar_concept_type, out.width="50%"}
+```{r bar_concept_type}
 dtPlot = dbGetQuery(con, "SELECT concept FROM week1")
 setDT(dtPlot)
 dtPlot = dtPlot[, .(count = .N), by = concept]
+unique_count = dtPlot[, .N]
 dtPlot = dtPlot[order(-count)][1:10]
 dtPlot[concept == "", concept := "NA"]
-cols = rainbow(10, s=col.par(10), v=col.par(10))
-ggplot(dtPlot, aes(x=reorder(concept,-count), y=count, fill = as.factor(concept))) + 
+ggplot(dtPlot, aes(x=reorder(concept,count), y=count, fill = as.factor(concept))) + 
   geom_bar(stat = "identity") + 
-  scale_fill_manual(values=cols) +
+  geom_text(aes(x=reorder(concept,count), y=count, label = format(count, big.mark = ',')), 
+            nudge_y = 1900000) + 
+  ylim(c(0,2.2e+07)) + 
   theme(axis.text.x = element_text(angle = 30, vjust = 1, hjust=1), 
-        legend.position="none") + 
-  xlab("concept type") +
-  ggtitle("Top 10 Concept Types (N = 30,694,912)", 
-          subtitle = "First week of October 2024")
+        legend.position="none", axis.title=element_blank()) + 
+  ggtitle("Top 10 Concept Types", 
+          subtitle = paste(
+            "Out of", unique_count, 
+            "concept types. First week of October 2024. N = 30,694,912")) +
+  coord_flip()
 ```
 
-  
+### Method
+
+```{r bar_method}
+dtPlot = dbGetQuery(con, "SELECT method FROM week1")
+setDT(dtPlot)
+dtPlot = dtPlot[, .(count = .N), by = method]
+ggplot(dtPlot, aes(x=reorder(method,-count), y=count, fill = as.factor(method))) + 
+  geom_bar(stat = "identity") + 
+  geom_text(aes(x=reorder(method,-count), y=count, label = format(count, big.mark = ',')), 
+            nudge_y = 1000000) + 
+  theme(axis.text.x = element_text(angle = 30, vjust = 1, hjust=1), 
+        legend.position="none") + 
+  xlab("HTTP method") +
+  ggtitle("HTTP Method", 
+          subtitle = "First week of October 2024. N = 30,694,912")
+```
+
+### Client ID
+
+```{r bar_clientID}
+dtPlot = dbGetQuery(con, "SELECT client_id FROM week1")
+setDT(dtPlot)
+dtPlot = dtPlot[, .(count = .N), by = client_id]
+unique_count = dtPlot[, .N]
+dtPlot = dtPlot[order(-count)][1:15]
+ggplot(dtPlot, aes(x=reorder(client_id,count), y=count, fill = as.factor(client_id))) + 
+  geom_bar(stat = "identity") + 
+  geom_text(aes(x=reorder(client_id,count), y=count, label = format(count, big.mark = ',')), 
+            nudge_y = 2500000, data = dtPlot[!is.na(client_id)]) + 
+  theme(axis.text.x = element_text(angle = 30, vjust = 1, hjust=1), 
+        legend.position="none", axis.title=element_blank()) + 
+  ggtitle(paste("Top", dtPlot[, .N], "Client IDs"), 
+          subtitle = paste(
+            "Out of", unique_count, 
+            "client IDs. First week of October 2024. N = 30,694,912")) + 
+  coord_flip()
+```
+
+### User Agent Type
+
+Note that "Web Browser" groups any agent that included the string "Mozilla," which most web browser user agents do.
+
+```{r bar_user_agent}
+dtPlot = dbGetQuery(con, "SELECT user_agent_type FROM week1")
+setDT(dtPlot)
+dtPlot = dtPlot[, .(count = .N), by = user_agent_type]
+unique_count = dtPlot[, .N]
+dtPlot = dtPlot[order(-count)][1:15]
+ggplot(dtPlot, aes(x=reorder(user_agent_type,count), y=count, fill = as.factor(user_agent_type))) + 
+  geom_bar(stat = "identity") + 
+  geom_text(aes(x=reorder(user_agent_type,count), y=count, label = format(count, big.mark = ',')), 
+            nudge_y = 1500000, data = dtPlot[!is.na(user_agent_type)]) + 
+  ylim(c(0,1.45e+07)) +
+  theme(axis.text.x = element_text(angle = 30, vjust = 1, hjust=1), 
+        legend.position="none", axis.title=element_blank()) + 
+  ggtitle(paste("Top", dtPlot[, .N], "User Agent Types"), 
+          subtitle = paste(
+            "Out of", unique_count, 
+            "user agent types. First week of October 2024. N = 30,694,912")) + 
+  coord_flip()
+```
+
+### Page Size
+
+All request counts in the plot below are \>= 1.
+
+```{r points_page_size}
+# Formats numbers less than 10000 in non-scientific notation
+conditional_scientific = function(x){
+  sapply(x, function(l){
+    if(l < 10000){
+      format(l, scientific = FALSE)
+    } else {
+      format(l, scientific = TRUE)
+    }
+  })
+}
+
+dtPlot = dbGetQuery(con, "SELECT page_size FROM week1")
+setDT(dtPlot)
+dtPlot = dtPlot[, .(count = .N), by = page_size]
+na_count = dtPlot[is.na(page_size), count]
+dtPlot = dtPlot[!is.na(page_size)]
+rm_count = dtPlot[page_size > 2000, sum(count)]
+dtPlot = dtPlot[page_size <= 2000]
+unique_count = dtPlot[, .N]
+#setkey(dtPlot, "page_size")
+ggplot(dtPlot, aes(x=page_size, y=count)) + 
+  geom_point() + 
+  theme(axis.text.x = element_text(angle = 30, vjust = 1, hjust=1), 
+        legend.position="none", axis.title=element_blank()) + 
+  xlab("Page Size") + ylab("Count") + 
+  scale_y_continuous(breaks = c(1, 1e+06, 2e+06), labels = conditional_scientific) + 
+  ggtitle("Request Count by Page Size",
+         subtitle = paste0("First week of October 2024. N = ", 
+                          format(dtPlot[, sum(count)], big.mark = ","), ". ",
+                          "Excludes NA and invalid requests"))
+```
+
+### Geometry Type
+
+```{r bar_geo_type}
+dtPlot = dbGetQuery(con, "SELECT geo_type FROM week1")
+setDT(dtPlot)
+dtPlot = dtPlot[, .(count = .N), by = geo_type]
+ggplot(dtPlot, aes(x=reorder(geo_type,-count), y=count, fill = as.factor(geo_type))) + 
+  geom_bar(stat = "identity") + 
+  geom_text(aes(x=reorder(geo_type,-count), y=count, label = format(count, big.mark = ',')), 
+            nudge_y = 1000000) + 
+  theme(axis.text.x = element_text(angle = 30, vjust = 1, hjust=1), 
+        legend.position="none", axis.title=element_blank()) + 
+  ggtitle("Geometry Type", 
+          subtitle = "First week of October 2024. N = 30,694,912")
+```
+
+### Polygon Area
+
+```{r susbet_dtAreas}
+dtAreas = dtAreas[!is.na(polygon_area) & polygon_area > 0, ]
+area_count = dtAreas[, .N]
+```
+
+Getting breaks for such a wide distribution was tricky. I started with Fisher-Jenks classification from the [`classInt` package](https://r-spatial.github.io/classInt/reference/classIntervals.html).
+
+```{r fisher_breaks_example}
+area_fisher_example = classInt::classIntervals(dtAreas$polygon_area, n = 5, style = "fisher")
+area_fisher_example
+```
+
+But it uses random sampling for large datasets, which makes the breaks not reproducible. Another challenge is the typical histogram plotting methods show the width of the bins with a constant scale on the plot axis, which can make simultaneously displaying some bins with a width in the hundreds and others with a width in the tens of millions impractical.
+
+Instead, I took the Fisher-Jenks bins as an inspiration for manual binning, increased resolution for small areas (where most of the values are), and then assigned them to discrete values to use in a bar plot.
+
+```{r area_binning}
+area_bins = c(1, 10, 100, 1000, 5000, 5e+07, 1e+08, 1e+09, max(dtAreas$polygon_area))
+area_hist = hist(dtAreas$polygon_area, breaks = area_bins, plot = FALSE)
+dtPlot = as.data.table(list(lower = area_hist$breaks[-length(area_hist$breaks)], 
+                            upper = area_hist$breaks[-1],
+                            counts = area_hist$counts))
+dtPlot[, bin := paste(conditional_scientific(lower), "-", 
+                      conditional_scientific(upper))]
+# Reduce significant digits in maximum label
+dtPlot[upper == max(upper), bin := paste(conditional_scientific(lower), "-", 
+                                         format(upper, digits = 3))]
+dtPlot
+```
+
+```{r bar_polygon_area}
+ggplot(dtPlot, aes(x=bin, y=counts)) + 
+  geom_bar(stat = "identity", fill = "#051399") + 
+  # `limits` sets the order, otherwise would be alphabetical
+  scale_x_discrete(limits = dtPlot$bin) + 
+  scale_y_continuous(breaks = seq(0,6e+05,2e+05), labels = \(l) format(l, scientific = FALSE, big.mark=',')) + 
+  ylab("count") + 
+  xlab("Area Bins (m²)") + 
+  theme(axis.text.x = element_text(angle = 30, vjust = 1, hjust=1), 
+        legend.position="none") + 
+  ggtitle("Polygon Area",
+          subtitle = paste("First week of October 2024. N =", format(area_count, big.mark=',')))
+```
+
+### Vertex Count
+
+Includes features of all types: points, lines, polygons, bounding boxes (converted to 5 vertex polygons) and circles (converted to 1 vertex points).
+
+As in the polygon area above, I did some experiments to find useful histogram breaks, and then wrote the breaks manually.
+
+```{r bar_vertex_count}
+vert_bins = c(1,1,2,3,4,5,20,100,200,1000,8000)
+vert_hist = hist(dtVert$vertex_count, breaks = vert_bins, plot = FALSE)
+dtPlot = as.data.table(list(lower = vert_hist$breaks[-length(vert_hist$breaks)], 
+                            upper = vert_hist$breaks[-1],
+                            counts = vert_hist$counts))
+dtPlot[, bin := paste(lower, "-", upper)]
+dtPlot[1:5, bin := 1:5]
+
+ggplot(dtPlot, aes(x=bin, y=counts)) + 
+  geom_bar(stat = "identity", fill = "#781399") + 
+  # `limits` sets the order, otherwise would be alphabetical
+  scale_x_discrete(limits = dtPlot$bin) + 
+  #scale_y_continuous(breaks = seq(0,6e+05,2e+05), labels = \(l) format(l, scientific = FALSE, big.mark=',')) + 
+  scale_y_continuous(labels = \(l) format(l, scientific = FALSE, big.mark=',')) + 
+  ylab("count") + 
+  theme(axis.text.x = element_text(angle = 30, vjust = 1, hjust=1), 
+        legend.position="none", axis.title.x=element_blank()) + 
+  ggtitle("Vertex Count, by Feature", 
+          subtitle = paste("First week of October 2024. N =", format(dtVert[, .N], big.mark=',')))
+```

--- a/cmr_logs_categorizer/categorize_queries.Rmd
+++ b/cmr_logs_categorizer/categorize_queries.Rmd
@@ -1,0 +1,463 @@
+---
+title: "Categorize CMR Queries"
+output: 
+  html_document:
+    TOC: TRUE
+    fig_width: 6
+    fig_height: 4
+---
+
+```{r setup, include=FALSE, echo=FALSE}
+# knitr::opts_knit$set(root.dir = '../dev/log_parsing')
+```
+
+
+```{r sources}
+suppressPackageStartupMessages({
+  library(data.table)
+  library(stringr)
+  library(sf)
+  library(arrow)
+  library(duckdb)
+  library(ggplot2)
+})
+source('analysis_functions.R')
+```
+
+
+```{r connect}
+con <- dbConnect(duckdb(), dbdir = "../dev/log_parsing/logs_week1.db")
+# dbExecute(con, "SET enable_object_cache=true")
+```
+
+## Load parquet into DuckDB DB
+
+Prepare column names
+```{r column_names, results='hide'}
+dtExample = dbGetQuery(con, "SELECT * FROM read_parquet('../dev/log_parsing/logs/**/*.parquet', union_by_name=true) LIMIT 1")
+column_names = names(dtExample)
+column_names[column_names == "client.id"] <- '"client.id" AS client_id' # rename client.id, removing period
+columns_except_id = paste(setdiff(column_names, "id"), collapse = ", ") # remove id column
+```
+
+Load parquet data into database file
+```{r create_db, results='hide'}
+dbExecute(con, paste(
+  'CREATE OR REPLACE TABLE week1 AS FROM (SELECT', 
+  columns_except_id,
+  'FROM read_parquet("../dev/log_parsing/logs/**/*.parquet", union_by_name=true)',
+  'ORDER BY now)'))
+```
+
+Check row count of created table
+```{r check_row_count}
+format(dbGetQuery(con, "SELECT COUNT(*) FROM week1")[1,1], big.mark=",")
+```
+
+### Example rows
+```{r}
+dbGetQuery(con, "SELECT * FROM week1 LIMIT 10")
+```
+
+Recalculate row ID column
+```{r rowID, results='hide'}
+dbExecute(con, paste(
+  "CREATE SEQUENCE id_seq START 1;",
+  "ALTER TABLE week1 ADD COLUMN id INTEGER DEFAULT nextval('id_seq');"
+))
+```
+
+## Spatial boolean
+```{r wkt_null_counts, include=FALSE}
+dbGetQuery(con, "SELECT COUNT(*) FROM week1 WHERE wkt IS NULL")
+dbGetQuery(con, "SELECT COUNT(*) FROM week1 WHERE wkt IS NOT NULL")
+```
+
+```{r spatial_bool, results='hide'}
+dbExecute(con, paste( 
+          "ALTER TABLE week1",
+          "ADD COLUMN spatial_bool BOOLEAN DEFAULT FALSE"))
+dbExecute(con, paste( 
+          "UPDATE week1",
+          "SET spatial_bool = TRUE",
+          "WHERE wkt IS NOT NULL"))
+```
+
+## Spatial complexity
+
+### Vertex Count
+```{r vertex_count}
+dtWKT = dbGetQuery(con, "SELECT wkt, id, geo_type FROM week1")
+setDT(dtWKT)
+dtWKT[, vertex_count := as.integer(count_vertices(wkt))]
+ecdf_fn_vert_count <- ecdf(dtWKT[!is.na(vertex_count), vertex_count])
+dtWKT[!is.na(vertex_count), vertex_pctile := round(ecdf_fn_vert_count(vertex_count), 6), by = vertex_count]
+dtWKT[!is.na(vertex_count), .N, by = .(vertex_count, vertex_pctile)][order(vertex_count)]
+```
+
+### Area
+```{r duckdb_spatial, include=FALSE}
+dbExecute(con, "INSTALL spatial; LOAD spatial")
+```
+
+```{r polygon_area, results='hide'}
+dbExecute(con, paste( 
+          "ALTER TABLE week1",
+          "ADD COLUMN polygon_area BIGINT"))
+```
+
+```{r duckdb_area, results='hide'}
+dbExecute(con, paste( 
+          "UPDATE week1",
+          "SET polygon_area = ST_AREA(ST_GeomFromText(wkt))",
+          "WHERE wkt IS NOT NULL AND geo_type == 'POLYGON'"))
+```
+
+```{r}
+dbGetQuery(con, "SELECT MAX(polygon_area) FROM week1 WHERE polygon_area IS NOT NULL")
+dtAreas = dbGetQuery(con, "SELECT id, polygon_area FROM week1 WHERE polygon_area IS NOT NULL")
+setDT(dtAreas)
+```
+
+```{r}
+ecdf_fn_area <- ecdf(dtAreas$polygon_area)
+dtAreas[!is.na(polygon_area), area_pctile := ecdf_fn_area(polygon_area), by = .(polygon_area)]
+dtAreas[!is.na(polygon_area), .N, by = .(polygon_area, area_pctile)][order(polygon_area)]
+```
+
+### Join Vertex Count and Area back to DuckDB table
+```{r add_area_vertex_columns, results='hide'}
+dbExecute(con, paste( 
+          "ALTER TABLE week1",
+          "ADD COLUMN vertex_count USMALLINT;",
+          "ALTER TABLE week1",
+          "ADD COLUMN vertex_pctile FLOAT;",
+          "ALTER TABLE week1",
+          "ADD COLUMN area_pctile FLOAT;"))
+```
+
+```{r register_areas_vertices, results='hide'}
+duckdb_register(con, "dtAreas", dtAreas)
+duckdb_register(con, "dtWKT", dtWKT)
+```
+
+```{r test_join, include=FALSE}
+dbGetQuery(con, paste(
+  "SELECT week1.id, week1.polygon_area, dtAreas.area_pctile",
+  "FROM week1",
+  "JOIN dtAreas",
+  "ON week1.id = dtAreas.id"
+))
+```
+```{r copy_area_pctile, results='hide'}
+dbExecute(con, paste(
+  "UPDATE week1",
+  "SET area_pctile = dtAreas.area_pctile",
+  "FROM dtAreas",
+  "WHERE week1.id = dtAreas.id"
+))
+```
+
+```{r test_copied_area_pctile, include=FALSE}
+dbGetQuery(con, paste(
+  "SELECT id, polygon_area, area_pctile",
+  "FROM week1",
+  "WHERE polygon_area IS NOT NULL"
+))
+dbGetQuery(con, paste(
+  "SELECT id, polygon_area, area_pctile",
+  "FROM week1",
+  "WHERE area_pctile >= 0.99"
+))
+```
+```{r copy_vertices, results='hide'}
+dbExecute(con, paste(
+  "UPDATE week1",
+  "SET vertex_count = dtWKT.vertex_count,",
+      "vertex_pctile = dtWKT.vertex_pctile",
+  "FROM dtWKT",
+  "WHERE week1.id = dtWKT.id"
+))
+```
+
+```{r test_copied_vertices, include=FALSE}
+dbGetQuery(con, paste(
+  "SELECT id, vertex_count, vertex_pctile",
+  "FROM week1",
+  "WHERE vertex_count IS NOT NULL"
+))
+```
+
+## Temporal Boolean
+
+```{r temporal_bool, include=FALSE}
+dbExecute(con, paste( 
+          "ALTER TABLE week1",
+          "ADD COLUMN temporal_bool BOOLEAN DEFAULT FALSE"))
+dbExecute(con, paste( 
+          "UPDATE week1",
+          "SET temporal_bool = TRUE",
+          "WHERE time_query IS NOT NULL"))
+```
+
+## Ordering Boolean
+
+```{r sort_bool, results='hide'}
+dbExecute(con, paste( 
+          "ALTER TABLE week1",
+          "ADD COLUMN sort_bool BOOLEAN DEFAULT FALSE"))
+dbExecute(con, paste( 
+          "UPDATE week1",
+          "SET sort_bool = TRUE",
+          "WHERE sort_key IS NOT NULL"))
+```
+
+### Multiple ordering
+
+```{r calculate_sort_count}
+dtOrders = dbGetQuery(con, "SELECT id, sort_key FROM week1 WHERE sort_key IS NOT NULL")
+setDT(dtOrders)
+dtOrders[, sort_count := count_vertices(sort_key)]
+dtOrders[, .N, by = sort_count][order(-N)]
+```
+
+```{r copy_sort_count, results='hide'}
+duckdb_register(con, "dtOrders", dtOrders)
+dbExecute(con, paste( 
+          "ALTER TABLE week1",
+          "ADD COLUMN sort_count TINYINT"))
+dbExecute(con, paste( 
+          "UPDATE week1",
+          "SET sort_count = dtOrders.sort_count",
+          "FROM dtOrders",
+          "WHERE week1.id = dtOrders.id"))
+```
+
+```{r test_sort_count, include=FALSE}
+dbGetQuery(con, paste(
+  "SELECT id, sort_count",
+  "FROM week1",
+  "WHERE sort_count IS NOT NULL"
+))
+```
+
+## Provider vs. Collection
+
+```{r create_prov_coll, results='hide'}
+dbExecute(con, paste( 
+          "ALTER TABLE week1",
+          "ADD COLUMN prov_coll CHARACTER DEFAULT ''"))
+```
+
+```{r update_prov_coll, results='hide'}
+dbExecute(con, paste( 
+          "UPDATE week1",
+          "SET prov_coll = 'Provider'",
+          "WHERE provider IS NOT NULL AND concept_id IS NULL")) # 7393219
+dbExecute(con, paste( 
+          "UPDATE week1",
+          "SET prov_coll = 'Collection'",
+          "WHERE provider IS NULL AND concept_id IS NOT NULL")) # 2651164
+dbExecute(con, paste( 
+          "UPDATE week1",
+          "SET prov_coll = 'Both'",
+          "WHERE provider IS NOT NULL AND concept_id IS NOT NULL")) # 4552353
+```
+
+## Category Creation
+
+Set NA values for Area and Vertex percentiles to 0
+```{r null_zero_percentiles, results='hide'}
+dbExecute(con, paste(
+  "UPDATE week1",
+  "SET area_pctile = 0",
+  "WHERE area_pctile IS NULL"
+))
+dbExecute(con, paste(
+  "UPDATE week1",
+  "SET vertex_pctile = 0",
+  "WHERE vertex_pctile IS NULL"
+))
+```
+
+```{r}
+dbExecute(con, paste(
+  "CREATE OR REPLACE VIEW cat1 AS FROM",
+  "(SELECT id, spatial_bool::UTINYINT || temporal_bool::UTINYINT || sort_bool::UTINYINT || (area_pctile>0.99)::UTINYINT || (vertex_pctile>0.99)::UTINYINT AS test_cat,",
+  "spatial_bool, temporal_bool, sort_bool, sort_count, polygon_area, vertex_count, cmr_took, prov_coll",
+  "FROM week1",
+  "WHERE concept == 'granules')"
+))
+```
+
+### Category Summaries
+
+Example query rows with categorization
+```{r}
+dbGetQuery(con, "SELECT test_cat, spatial_bool, temporal_bool, sort_bool, sort_count, polygon_area, vertex_count, cmr_took FROM cat1 ORDER BY cmr_took DESC LIMIT 1000")
+```
+```{r time_by_cat_old, include=FALSE}
+time_by_cat = dbGetQuery(con, "SELECT test_cat, COUNT(*) AS count, AVG(cmr_took) AS mean_cmr_took FROM cat1 GROUP BY test_cat ORDER BY mean_cmr_took")
+setDT(time_by_cat)
+time_by_cat
+```
+
+Summarize query time by category
+```{r time_by_cat}
+time_by_cat = dbGetQuery(con, paste(
+  "SELECT test_cat,",
+  "COUNT(*) AS count, AVG(cmr_took) AS mean_cmr_took,",
+  "substring(test_cat,1,1)::LOGICAL AS Spatial,",
+  "substring(test_cat,2,1)::LOGICAL AS Temporal,",
+  "substring(test_cat,3,1)::LOGICAL AS Sort,",
+  "substring(test_cat,4,1)::LOGICAL AS Area99,",
+  "substring(test_cat,5,1)::LOGICAL AS Vertex99",
+  "FROM cat1 GROUP BY test_cat ORDER BY mean_cmr_took"))
+setDT(time_by_cat)
+time_by_cat
+```
+
+Take a look at 10110's provider/collection ratio
+- spatial, sort, 99th percentile area
+```{r}
+dbGetQuery(con, "SELECT COUNT(*) AS count, prov_coll, AVG(cmr_took) AS mean_cmr_took FROM cat1 WHERE test_cat == '10110' GROUP BY prov_coll")
+```
+### Current test suite coverage
+
+Check percentile of the vertex count and area of CA shape used in benchmark suite
+
+```{r}
+paste("CA shape vertex percentile:", ecdf_fn_vert_count(426)) # 0.9998834
+ca_wkt = readLines("tmp_ca_verts")
+ca_shp = st_as_sfc(ca_wkt, crs = "EPSG:4326")
+#st_area(ca_shp) # 410506579297 [m^2]
+suppressMessages(sf_use_s2(FALSE))
+ca_area = st_area(ca_shp)
+paste("CA shape area percentile:  ", ecdf_fn_area(ca_area)) # 410680461757 [m^2]
+ca_bbox_area = st_area(st_as_sfc("POLYGON ((-124.409202 32.531669, -114.119061 32.531669, -114.119061 41.99954, -124.409202 41.99954, -124.409202 32.531669))", crs = "EPSG:4326"))
+paste("CA BBOX area percentile:   ", ecdf_fn_area(ca_bbox_area))
+suppressMessages(sf_use_s2(TRUE))
+```
+spatial_bool, temporal_bool, sort_bool, polygon_area, vertex_count
+```{r categorized_benchmark_suite}
+bigstac_suite8 = c(
+  BBOX_time_sort_largeArea = "11110",
+  shape_time_sort_largeArea_largeVertex = "11111",
+  time_sort = "01100",
+  BBOX_time_largeArea = "11010",
+  shape_time_largeArea_largeVertex = "11011",
+  time = "01000"
+)
+dtSuite8 = stack(bigstac_suite8)
+setDT(dtSuite8)
+setnames(dtSuite8, new = c("test_cat", "test_type"))
+dtSuite8
+```
+Note that we tested with a shape that is both very complex in vertices and very large area - a combination that was not seen in the query data.
+```{r benchmark_categories_log_summary}
+setkey(time_by_cat, "test_cat")
+setkey(dtSuite8, "test_cat")
+time_by_cat[dtSuite8, .(test_cat, count, mean_cmr_took, test_type)]
+```
+```{r coverage1}
+paste("The latest benchmark suite would cover",
+      scales::label_percent()(time_by_cat[dtSuite8, sum(count, na.rm = TRUE)]/time_by_cat[, sum(count)]),
+      "of queries")
+```
+
+
+```{r non_covered_classes}
+non_covered_classes = time_by_cat[!dtSuite8][order(mean_cmr_took)]
+non_covered_classes
+```
+
+But a large portion of the queries are trivial - ones with zero or few parameters that return quickly.
+What proportion of the queries does the benchmark suite cover if we exclude the two classes with the fastest processing time and large number of queries? "10000" and "00000"
+```{r coverage2}
+paste("The latest benchmark suite would cover",
+      scales::label_percent()(time_by_cat[dtSuite8, sum(count, na.rm = TRUE)]/
+                                time_by_cat[!test_cat %in% c("00000", "10000"), sum(count)]),
+      "of non-trivial queries")
+```
+
+### Categories of Interest
+
+We have 16 categories in this one week sample of CMR queries. For common categories, look at their probability distributions for CMR processing time.
+
+Below is a table of the most common categories. 
+
+```{r most_common_categories}
+time_by_cat[order(-count)]
+```
+
+We will use the top 6 categories, which each have over 1 million queries.
+
+```{r}
+cat6 = time_by_cat[order(-count)][1:6, test_cat]
+cat6
+```
+
+Which of these are in the current benchmark suite?
+```{r}
+dtSuite8[test_cat %in% cat6]
+```
+
+Which categories in the benchmark suite are not in the top 6 most common categories?
+```{r}
+dtSuite8[!test_cat %in% cat6]
+```
+
+```{r}
+time_by_cat[test_cat %in% cat6]
+time_by_cat[test_cat %in% dtSuite8$test_cat]
+```
+
+### Density of CMR time by query categories
+```{r}
+dtCatTime = dbGetQuery(con, "SELECT test_cat, cmr_took FROM cat1")
+setDT(dtCatTime)
+dtCatTime = dtCatTime[!is.na(cmr_took)] # 97% of granule query REPORTs include `cmr_took`
+setkey(dtCatTime, "test_cat")
+```
+
+```{r}
+dtCatTimeSub = dtCatTime[test_cat %in% cat6]
+dtCatTimeSub[, test_cat := as.factor(test_cat)]
+p_dens_cats <- ggplot(dtCatTimeSub, aes(cmr_took, color = test_cat, fill = test_cat))+
+  geom_density(alpha = 0.06) +
+  xlim(c(0,2500)) + 
+  labs(color='Category', fill = 'Category') +
+  guides(color = guide_legend(position = "inside"))
+```
+```{r}
+p_dens_cats + theme(legend.position.inside = c(0.93, 0.75))
+```
+
+
+
+## Other Analysis
+
+```{r}
+col.par = function(n) sample(seq(0.3, 1, length.out=50),n)
+```
+
+### Concept Types
+
+```{r bar_concept_type, out.width="50%"}
+dtPlot = dbGetQuery(con, "SELECT concept FROM week1")
+setDT(dtPlot)
+dtPlot = dtPlot[, .(count = .N), by = concept]
+dtPlot = dtPlot[order(-count)][1:10]
+dtPlot[concept == "", concept := "NA"]
+cols = rainbow(10, s=col.par(10), v=col.par(10))
+ggplot(dtPlot, aes(x=reorder(concept,-count), y=count, fill = as.factor(concept))) + 
+  geom_bar(stat = "identity") + 
+  scale_fill_manual(values=cols) +
+  theme(axis.text.x = element_text(angle = 30, vjust = 1, hjust=1), 
+        legend.position="none") + 
+  xlab("concept type") +
+  ggtitle("Top 10 Concept Types (N = 30,694,912)", 
+          subtitle = "First week of October 2024")
+```
+
+  

--- a/cmr_logs_categorizer/categorize_queries.Rmd
+++ b/cmr_logs_categorizer/categorize_queries.Rmd
@@ -11,6 +11,16 @@ output:
     df_print: paged
 ---
 
+**Questions?**  
+Contact [Johnathan Rush](mailto:johnathan.f.rush@nasa.gov), NASA EED-3
+
+```{css, echo=FALSE}
+/* Make the commentary text a little larger than code cells and cell output */
+p {
+  font-size: 16px;
+}
+```
+
 ```{r sources}
 suppressPackageStartupMessages({
   library(data.table)
@@ -514,7 +524,9 @@ The following categories in the logged CMR queries were not covered by the lates
 p_cats[!dtSuite8][order(p0.5)]
 ```
 
-But a large portion of these queries are easier than others: the ones in the `00000` category have none of the query parameters we've selected as being interesting for performance. What proportion of the queries does the benchmark suite cover if we exclude this category with the fastest median processing time and the largest number of queries?
+A large portion of these queries are easier than others: the ones in the `00000` category have none of the query parameters we've selected as being interesting for performance.
+
+What proportion of the queries does the benchmark suite cover if we exclude this category with the fastest median processing time and the largest number of queries?
 
 ```{r coverage2}
 paste("The latest benchmark suite would cover",
@@ -523,7 +535,8 @@ paste("The latest benchmark suite would cover",
       "of non-trivial queries")
 ```
 
-However, we wouldn't want to exclude this category from consideration during the design of Bigstac, given that it represents a plurality of queries. There is also significant variation within this category, as seen by the 1.3s difference between the 50th and 95th percentile performance. Possible routes for explanation of that variance would be looking at variables not included in the categories, like requested page size, or calculating a measurement of CMR load using a window function to count the number of queries received in the surrounding X minutes. Other possible explanations would not be in the `cmr-logs` log group, like load introduced by data ingestion.
+However, we wouldn't want to exclude this category from consideration during the design of Bigstac, given that it represents a plurality of queries.  
+There is also significant variation within this category, as seen by the greater than 1 second difference between the 50th and 95th percentile performance. Possible routes for explanation of that variance would be looking at variables not included in the categories, like requested page size, or calculating a measurement of CMR load using a window function to count the number of queries received in the surrounding X minutes. Other possible explanations would not be in the `cmr-logs` log group, like load introduced by data ingestion.
 
 ## Selecting Categories of Interest
 
@@ -551,7 +564,7 @@ Top `r top_count` categories
 ```{r top_cats}
 p_cats[test_cat %in% top_cats]
 ```
-### Relative to benchmark suite categories
+### Relative to benchmark suite
 
 Which of the top `r top_count` categories are in the current benchmark suite?
 
@@ -572,7 +585,7 @@ Below are the 4 categories from the benchmark suite that exist in the log data. 
 p_cats[test_cat %in% dtSuite8$test_cat]
 ```
 
-### Density of CMR time by query categories
+### Density of CMR time
 
 ```{r cmr_time_density_setup}
 dtCatTimeSub = dtCatTime[test_cat %in% top_cats]
@@ -586,7 +599,7 @@ p_dens_cats <- ggplot(dtCatTimeSub, aes(cmr_took, color = test_cat, fill = test_
 p_dens_cats
 ```
 
-## Other Analysis
+## Other Summaries
 
 ### Concept Types
 

--- a/cmr_logs_categorizer/categorize_queries.Rmd
+++ b/cmr_logs_categorizer/categorize_queries.Rmd
@@ -2,15 +2,14 @@
 title: "Categorize CMR Queries"
 output: 
   html_document:
-    TOC: TRUE
-    fig_width: 6
-    fig_height: 4
+    toc: true
+    toc_depth: 3
+    toc_float: 
+       collapsed: false
+    fig_width: 9
+    fig_height: 6
+    df_print: paged
 ---
-
-```{r setup, include=FALSE, echo=FALSE}
-# knitr::opts_knit$set(root.dir = '../dev/log_parsing')
-```
-
 
 ```{r sources}
 suppressPackageStartupMessages({

--- a/cmr_logs_categorizer/categorize_queries.Rmd
+++ b/cmr_logs_categorizer/categorize_queries.Rmd
@@ -76,10 +76,10 @@ columns_except_id = paste(setdiff(column_names, "id"), collapse = ", ")
 Load parquet data into database file
 
 ```{r create_db, results='hide'}
-if(modifyDB) { dbExecute(con, paste(
-  'CREATE OR REPLACE TABLE week1 AS FROM (SELECT', 
+if(modifyDB) { dbExecute(con, paste0(
+  'CREATE OR REPLACE TABLE week1 AS FROM (SELECT ', 
   columns_except_id,
-  'FROM read_parquet("../dev/log_parsing/logs/**/*.parquet", union_by_name=true)',
+  ' FROM read_parquet("', log_export_directory, '/**/*.parquet", union_by_name=true) ',
   'ORDER BY now)')) }
 ```
 
@@ -127,7 +127,7 @@ if(modifyDB) {
   dbExecute(con, paste( 
             "UPDATE week1",
             "SET spatial_bool = TRUE",
-            "WHERE wkt IS NOT NULL"))
+            "WHERE geo_type IS NOT NULL"))
 }
 ```
 
@@ -386,8 +386,15 @@ if(modifyDB) {
 if(modifyDB) { 
   dbExecute(con, paste(
     "CREATE OR REPLACE VIEW cat1 AS FROM",
-    "(SELECT id, spatial_bool::UTINYINT || temporal_bool::UTINYINT || sort_bool::UTINYINT || (area_pctile>0.99)::UTINYINT || (vertex_pctile>0.99)::UTINYINT AS test_cat,",
-    "spatial_bool, temporal_bool, sort_bool, sort_count, polygon_area, vertex_count, cmr_took, prov_coll",
+    "(SELECT",
+    "id,",
+    # Create 5-bit binary category variable from 5 booleans
+    "spatial_bool::UTINYINT || temporal_bool::UTINYINT ||",
+      "sort_bool::UTINYINT || (area_pctile>0.99)::UTINYINT ||",
+      "(vertex_pctile>0.99)::UTINYINT",
+      "AS test_cat,",
+    "spatial_bool, temporal_bool, sort_bool, sort_count,",
+    "polygon_area, vertex_count, duration, prov_coll",
     "FROM week1",
     "WHERE concept == 'granules')"
   ))
@@ -399,21 +406,15 @@ if(modifyDB) {
 Example query rows with categorization
 
 ```{r example_queries_with_categories}
-(dbGetQuery(con, "SELECT test_cat, cmr_took, spatial_bool, temporal_bool, sort_bool, sort_count, polygon_area, vertex_count FROM cat1 ORDER BY cmr_took DESC LIMIT 100"))
+(dbGetQuery(con, "SELECT test_cat, duration, spatial_bool, temporal_bool, sort_bool, sort_count, polygon_area, vertex_count FROM cat1 ORDER BY duration DESC LIMIT 100"))
 ```
 
 ```{r dtCatTime}
-dtCatTime = dbGetQuery(con, "SELECT test_cat, cmr_took FROM cat1")
+dtCatTime = dbGetQuery(con, "SELECT test_cat, duration FROM cat1")
 setDT(dtCatTime)
-dtCatTime = dtCatTime[!is.na(cmr_took)]
+dtCatTime = dtCatTime[!is.na(duration)]
 setkey(dtCatTime, "test_cat")
 ```
-
-```{r missing_cmr_took, include=FALSE}
-missing_cmr_took = dtCatTime[is.na(cmr_took), .N]/dtCatTime[, .N]
-```
-
-Around `r label_percent(accuracy = 0.1)(missing_cmr_took)` of rows in this period are missing `cmr_took`. In the future, it may be worthwhile to fill those values with `duration` when it is available (not currently extracted into parquet files by `log_to_table.R`). The two values tend to be very similar.
 
 ### CMR processing time percentiles
 
@@ -421,7 +422,7 @@ Around `r label_percent(accuracy = 0.1)(missing_cmr_took)` of rows in this perio
 unique_cats = dtCatTime[, unique(test_cat)]
 cmr_percentile <- function(unique_cats, percentile){
   cat_perc = sapply(unique_cats, function(x){
-    quantile(dtCatTime[test_cat == x, cmr_took], probs = percentile)
+    quantile(dtCatTime[test_cat == x, duration], probs = percentile)
   })
   names(cat_perc) <- unique_cats
   dt = stack(cat_perc)
@@ -431,17 +432,18 @@ cmr_percentile <- function(unique_cats, percentile){
 }
 p50_cats = cmr_percentile(unique_cats, 0.5)
 p95_cats = cmr_percentile(unique_cats, 0.95)
+p99_cats = cmr_percentile(unique_cats, 0.99)
 
 # Calculate count of queries per category
 counts_cats = dtCatTime[, .(count = .N), by = test_cat]
 
-p_cats = p50_cats[p95_cats][counts_cats]
+p_cats = p50_cats[p95_cats][p99_cats][counts_cats]
 ```
 
 Add columns explaining the binary coded category values
 
 ```{r percentile_by_category}
-p_cats = p_cats[, .(test_cat, count, p0.5, p0.95, 
+p_cats = p_cats[, .(test_cat, count, p0.5, p0.95, p0.99,
   Spatial = as.logical(as.integer(str_sub(test_cat,1,1))),
   Temporal = as.logical(as.integer(str_sub(test_cat,2,2))),
   Sort = as.logical(as.integer(str_sub(test_cat,3,3))),
@@ -471,20 +473,35 @@ Our benchmark suite used two spatial features: a polygon of California (a simpli
 Check percentile of the vertex count and area of CA shape used in benchmark suite:
 
 ```{r ca_percentiles, results='hold'}
-paste("CA shape vertex percentile:", ecdf_fn_vert_count(426)) # 0.9998834
-ca_wkt = readLines("tmp_ca_verts")
-ca_shp = st_as_sfc(ca_wkt, crs = "EPSG:4326")
-#st_area(ca_shp) # 410506579297 [m^2] using S2 (spherical)
+ca_raw = system2(
+  command = "jq", 
+  args = paste(
+    "'.tests[] |",
+    "select(.name==\"MBR-LIR-California_simplified-time_Since2020-SortBy_GranuleUR\")",
+    "| .raw' ../tester/suite8.json"), 
+  stdout = TRUE)
+ca_wkt = str_sub(ca_raw, 
+                 str_locate(ca_raw, "MULTIPOLYGON")[1], 
+                 str_locate(ca_raw, "'::GEOMETRY")[1]-1)
 
-# The area calculations in DuckDB used the GEOS library, which is what SF will
-# use if we disable S2.
+ca_shp = st_as_sfc(ca_wkt, crs = "EPSG:4326")
+#st_area(ca_shp) # 410,506,579,297 [m^2] using S2 (spherical)
+
+# The area calculations in DuckDB used the GEOS library. For consistency, we
+# will do the same with the R SF package by disabling its use of the S2 library.
 suppressMessages(sf_use_s2(FALSE)) 
-ca_area = st_area(ca_shp)
-paste("CA shape area percentile:  ", ecdf_fn_area(ca_area)) # 410680461757 [m^2] using GEOS (planar)
+ca_area = st_area(ca_shp) # 410,680,461,757 [m^2] using GEOS (planar)
+paste("CA shape area percentile:  ", ecdf_fn_area(ca_area))
 ca_bbox_area = st_area(st_as_sfc("POLYGON ((-124.409202 32.531669, -114.119061 32.531669, -114.119061 41.99954, -124.409202 41.99954, -124.409202 32.531669))", crs = "EPSG:4326"))
 paste("CA BBOX area percentile:   ", ecdf_fn_area(ca_bbox_area))
 suppressMessages(sf_use_s2(TRUE))
+
+ca_verts = count_vertices(ca_wkt)
+paste("CA shape vertex percentile:", ecdf_fn_vert_count(ca_verts))
+paste("CA shape vertex count:", ca_verts)
 ```
+
+Now that we have calculated area and vertex percentiles for the CA test geometries, we can categorize the benchmark queries in the same way as the logged queries.
 
 For reference, the binary category variable order is:\
 `spatial_bool`, `temporal_bool`, `sort_bool`, `polygon_area`, `vertex_count`
@@ -548,7 +565,7 @@ p_cats[order(-count)]
 ```
 
 ```{r top_cats_percentage}
-top_count = 6
+top_count = 7
 top_cats_percentage = p_cats[order(-count)][1:top_count, sum(count)]/p_cats[, sum(count)]
 top_cats_percentage
 ```
@@ -580,7 +597,7 @@ dtSuite8[!test_cat %in% top_cats]
 ```
 As discussed earlier, 2 of these are categories with both 99th percentile area and vertex counts, which were not observed in the logged queries at all.
 
-Below are the 4 categories from the benchmark suite that exist in the log data. Note the most common category below is also in the top `r top_count` set above.
+Below are the 4 categories from the benchmark suite that exist in the log data. Note the two most common categories below are also in the top `r top_count` set above.
 
 ```{r suite_cats}
 p_cats[test_cat %in% dtSuite8$test_cat]
@@ -591,7 +608,7 @@ p_cats[test_cat %in% dtSuite8$test_cat]
 ```{r cmr_time_density_setup}
 dtCatTimeSub = dtCatTime[test_cat %in% top_cats]
 dtCatTimeSub[, test_cat := as.factor(test_cat)]
-p_dens_cats <- ggplot(dtCatTimeSub, aes(cmr_took, color = test_cat, fill = test_cat))+
+p_dens_cats <- ggplot(dtCatTimeSub, aes(duration, color = test_cat, fill = test_cat))+
   geom_density(alpha = 0.06) +
   xlim(c(0,2500)) + # limiting this range is what generates the warning in the plot
   labs(color='Category', fill = 'Category') +
@@ -600,16 +617,37 @@ p_dens_cats <- ggplot(dtCatTimeSub, aes(cmr_took, color = test_cat, fill = test_
 p_dens_cats
 ```
 
+### CMR Duration by Category
+
+For the top `r top_count` most common categories
+
+```{r}
+dtPlot = p_cats[test_cat %in% top_cats]
+setnames(dtPlot, 'p0.5', 'p0.50')
+dtPlot = melt.data.table(dtPlot, id.vars = 'test_cat',
+                         measure.vars = c('p0.99', 'p0.95', 'p0.50'))
+setnames(dtPlot, 'variable', 'Percentile')
+ggplot(dtPlot, aes(x = test_cat, y = value, fill = Percentile)) + 
+  geom_bar(stat = "identity", position = "identity") + 
+  xlab("Category") + ylab("ms")
+```
+
+
 ## Other Summaries
 
 ### Concept Types
 
+The concept types are extracted from the request URLs, and the the large number of total concept types results from numerous requests for invalid pages that weren't cleaned from this data.
+
+In the plot below, `search/` represents the default search query with no parameters.
+
 ```{r bar_concept_type}
+plot_limit = 15
 dtPlot = dbGetQuery(con, "SELECT concept FROM week1")
 setDT(dtPlot)
 dtPlot = dtPlot[, .(count = .N), by = concept]
 unique_count = dtPlot[, .N]
-dtPlot = dtPlot[order(-count)][1:10]
+dtPlot = dtPlot[order(-count)][1:plot_limit]
 dtPlot[concept == "", concept := "NA"]
 ggplot(dtPlot, aes(x=reorder(concept,count), y=count, fill = as.factor(concept))) + 
   geom_bar(stat = "identity") + 
@@ -618,7 +656,7 @@ ggplot(dtPlot, aes(x=reorder(concept,count), y=count, fill = as.factor(concept))
   ylim(c(0,2.2e+07)) + 
   theme(axis.text.x = element_text(angle = 30, vjust = 1, hjust=1), 
         legend.position="none", axis.title=element_blank()) + 
-  ggtitle("Top 10 Concept Types", 
+  ggtitle(paste("Top", plot_limit,"Concept Types"), 
           subtitle = paste(
             "Out of", unique_count, 
             "concept types. First week of October 2024. N = 30,694,912")) +
@@ -631,7 +669,6 @@ ggplot(dtPlot, aes(x=reorder(concept,count), y=count, fill = as.factor(concept))
 dtPlot = dbGetQuery(con, "SELECT format FROM week1")
 setDT(dtPlot)
 dtPlot = dtPlot[, .(count = .N), by = format]
-unique_count = dtPlot[, .N]
 dtPlot = dtPlot[order(-count)]
 ggplot(dtPlot, aes(x=reorder(format,count), y=count, fill = as.factor(format))) + 
   geom_bar(stat = "identity") + 
@@ -665,22 +702,45 @@ ggplot(dtPlot, aes(x=reorder(method,-count), y=count, fill = as.factor(method)))
 
 ### Client ID
 
-```{r bar_clientID}
+First we'll group some records together that belong to the same product.
+```{r prep_clientID}
 dtPlot = dbGetQuery(con, "SELECT client_id FROM week1")
 setDT(dtPlot)
+dtPlot = dtPlot[!is.na(client_id)] # remove NA values
+
+dtPlot[str_detect(client_id, regex("asf_search", ignore_case = T)), 
+       client_id := "ASF Search"]
+dtPlot[str_detect(client_id, regex("eed-edsc", ignore_case = T)), 
+       client_id := "Earthdata Search"]
+dtPlot[str_detect(client_id, regex("eed-mmt", ignore_case = T)), 
+       client_id := "MMT"]
+dtPlot[str_detect(client_id, regex("AppEEARS", ignore_case = T)), 
+       client_id := "AppEEARS"]
+dtPlot[str_detect(client_id, regex("CMR2IMS", ignore_case = T)), 
+       client_id := "CMR2IMS"]
+dtPlot[str_detect(client_id, regex("cmr-stac", ignore_case = T)), 
+       client_id := "cmr-stac"]
+```
+
+```{r bar_clientID}
+plot_limit = 20
+row_count = dtPlot[, .N]
 dtPlot = dtPlot[, .(count = .N), by = client_id]
 unique_count = dtPlot[, .N]
-dtPlot = dtPlot[order(-count)][1:15]
+dtPlot = dtPlot[order(-count)][1:plot_limit]
 ggplot(dtPlot, aes(x=reorder(client_id,count), y=count, fill = as.factor(client_id))) + 
   geom_bar(stat = "identity") + 
   geom_text(aes(x=reorder(client_id,count), y=count, label = format(count, big.mark = ',')), 
-            nudge_y = 2500000, data = dtPlot[!is.na(client_id)]) + 
+            nudge_y = 300000, data = dtPlot[!is.na(client_id)]) + 
+  ylim(c(0, 3e+06)) + 
   theme(axis.text.x = element_text(angle = 30, vjust = 1, hjust=1), 
-        legend.position="none", axis.title=element_blank()) + 
-  ggtitle(paste("Top", dtPlot[, .N], "Client IDs"), 
+        legend.position="none", axis.title=element_blank(),
+        plot.title.position = "plot") + 
+  ggtitle(paste("Top", plot_limit, "Client IDs"), 
           subtitle = paste(
-            "Out of", unique_count, 
-            "client IDs. First week of October 2024. N = 30,694,912")) + 
+            "Excludes NA values. Out of", unique_count, 
+            "client IDs. First week of October 2024. N =",
+            format(row_count, big.mark = ','))) + 
   coord_flip()
 ```
 
@@ -689,11 +749,12 @@ ggplot(dtPlot, aes(x=reorder(client_id,count), y=count, fill = as.factor(client_
 Note that "Web Browser" groups any agent that included the string "Mozilla," which most web browser user agents do.
 
 ```{r bar_user_agent}
+plot_limit = 15
 dtPlot = dbGetQuery(con, "SELECT user_agent_type FROM week1")
 setDT(dtPlot)
 dtPlot = dtPlot[, .(count = .N), by = user_agent_type]
 unique_count = dtPlot[, .N]
-dtPlot = dtPlot[order(-count)][1:15]
+dtPlot = dtPlot[order(-count)][1:plot_limit]
 ggplot(dtPlot, aes(x=reorder(user_agent_type,count), y=count, fill = as.factor(user_agent_type))) + 
   geom_bar(stat = "identity") + 
   geom_text(aes(x=reorder(user_agent_type,count), y=count, label = format(count, big.mark = ',')), 
@@ -701,7 +762,7 @@ ggplot(dtPlot, aes(x=reorder(user_agent_type,count), y=count, fill = as.factor(u
   ylim(c(0,1.45e+07)) +
   theme(axis.text.x = element_text(angle = 30, vjust = 1, hjust=1), 
         legend.position="none", axis.title=element_blank()) + 
-  ggtitle(paste("Top", dtPlot[, .N], "User Agent Types"), 
+  ggtitle(paste("Top", plot_limit, "User Agent Types"), 
           subtitle = paste(
             "Out of", unique_count, 
             "user agent types. First week of October 2024. N = 30,694,912")) + 
@@ -732,7 +793,6 @@ dtPlot = dtPlot[!is.na(page_size)]
 rm_count = dtPlot[page_size > 2000, sum(count)]
 dtPlot = dtPlot[page_size <= 2000]
 unique_count = dtPlot[, .N]
-#setkey(dtPlot, "page_size")
 ggplot(dtPlot, aes(x=page_size, y=count)) + 
   geom_point() + 
   theme(axis.text.x = element_text(angle = 30, vjust = 1, hjust=1), 
@@ -745,20 +805,45 @@ ggplot(dtPlot, aes(x=page_size, y=count)) +
                           "Excludes NA and invalid requests"))
 ```
 
+### Temporal Query Type
+
+```{r bar_time_type}
+dtPlot = dbGetQuery(con, "SELECT time_type FROM week1")
+setDT(dtPlot)
+dtPlot = dtPlot[!is.na(time_type)]
+row_count = dtPlot[, .N]
+dtPlot = dtPlot[, .(count = .N), by = time_type]
+# Remove leading "params" from some time types
+dtPlot[str_detect(time_type, 'params\\.'), 
+       time_type := str_split_i(time_type, 'params\\.', 2)]
+ggplot(dtPlot, aes(x=reorder(time_type,-count), y=count, fill = as.factor(time_type))) + 
+  geom_bar(stat = "identity") + 
+  geom_text(aes(x=reorder(time_type,-count), y=count, label = format(count, big.mark = ',')), 
+            nudge_y = 400000) + 
+  theme(axis.text.x = element_text(angle = 30, vjust = 1, hjust=1), 
+        legend.position="none", axis.title=element_blank()) + 
+  ggtitle("Temporal Query Type", 
+          subtitle = paste("First week of October 2024. N =",
+            format(row_count, big.mark = ',')))
+```
+
 ### Geometry Type
 
 ```{r bar_geo_type}
 dtPlot = dbGetQuery(con, "SELECT geo_type FROM week1")
 setDT(dtPlot)
+dtPlot = dtPlot[!is.na(geo_type)]
+row_count = dtPlot[, .N]
 dtPlot = dtPlot[, .(count = .N), by = geo_type]
 ggplot(dtPlot, aes(x=reorder(geo_type,-count), y=count, fill = as.factor(geo_type))) + 
   geom_bar(stat = "identity") + 
   geom_text(aes(x=reorder(geo_type,-count), y=count, label = format(count, big.mark = ',')), 
-            nudge_y = 1000000) + 
+            nudge_y = 250000) + 
   theme(axis.text.x = element_text(angle = 30, vjust = 1, hjust=1), 
         legend.position="none", axis.title=element_blank()) + 
   ggtitle("Geometry Type", 
-          subtitle = "First week of October 2024. N = 30,694,912")
+          subtitle = paste("First week of October 2024. N =",
+            format(row_count, big.mark = ',')))
 ```
 
 ### Polygon Area

--- a/cmr_logs_categorizer/categorize_queries.Rmd
+++ b/cmr_logs_categorizer/categorize_queries.Rmd
@@ -29,6 +29,7 @@ suppressPackageStartupMessages({
   library(arrow)
   library(duckdb)
   library(ggplot2)
+  library(scales)
 })
 source('analysis_functions.R')
 ```
@@ -412,7 +413,7 @@ setkey(dtCatTime, "test_cat")
 missing_cmr_took = dtCatTime[is.na(cmr_took), .N]/dtCatTime[, .N]
 ```
 
-Around `r scales::label_percent()(missing_cmr_took)` of rows in this period are missing `cmr_took`. In the future, it may be worthwhile to fill those values with `duration` when it is available (not currently extracted into parquet files by `log_to_table.R`). The two values tend to be very similar.
+Around `r label_percent(accuracy = 0.1)(missing_cmr_took)` of rows in this period are missing `cmr_took`. In the future, it may be worthwhile to fill those values with `duration` when it is available (not currently extracted into parquet files by `log_to_table.R`). The two values tend to be very similar.
 
 ### CMR processing time percentiles
 
@@ -513,7 +514,7 @@ p_cats[dtSuite8, ]
 
 ```{r coverage1}
 paste("The latest benchmark suite would cover",
-      scales::label_percent()(
+      label_percent(accuracy = 0.1)(
         dtCatTime[dtSuite8, .N]/dtCatTime[, .N]),
       "of queries")
 ```
@@ -530,7 +531,7 @@ What proportion of the queries does the benchmark suite cover if we exclude this
 
 ```{r coverage2}
 paste("The latest benchmark suite would cover",
-      scales::label_percent()(dtCatTime[dtSuite8, .N]/
+      label_percent(accuracy = 0.1)(dtCatTime[dtSuite8, .N]/
                                 dtCatTime[!test_cat %in% c("00000"), .N]),
       "of non-trivial queries")
 ```
@@ -552,7 +553,7 @@ top_cats_percentage = p_cats[order(-count)][1:top_count, sum(count)]/p_cats[, su
 top_cats_percentage
 ```
 
-We need to keep in mind some existing realistic query patterns when designing Bigstac. If we were to focus on the top `r top_count` most common categories, they would represent `r scales::label_percent()(top_cats_percentage)` of the queries. After the top `r top_count` categories, there is a larger drop in query counts.
+We need to keep in mind some existing realistic query patterns when designing Bigstac. If we were to focus on the top `r top_count` most common categories, they would represent `r label_percent(accuracy = 0.1)(top_cats_percentage)` of the queries. After the top `r top_count` categories, there is a larger drop in query counts.
 
 ```{r top_size_cats}
 top_cats = p_cats[order(-count)][1:top_count, test_cat]

--- a/cmr_logs_categorizer/categorize_queries.Rmd
+++ b/cmr_logs_categorizer/categorize_queries.Rmd
@@ -36,7 +36,9 @@ This notebook gathers and prepares data, and includes some database operations (
 If this is the first time you've tun this code, or you've changed the database path above this block to point to a new file, you can set it to `TRUE`.
 
 ```{r connect}
-con <- dbConnect(duckdb(), dbdir = "../dev/log_parsing/logs_week1.db")
+log_parent_directory = "../dev/log_parsing"
+con <- dbConnect(duckdb(), 
+                 dbdir = paste0(log_parent_directory, "/logs_week1.db"))
 ```
 ```{r modifyDB}
 modifyDB = FALSE
@@ -47,10 +49,17 @@ modifyDB = FALSE
 Prepare column names
 
 ```{r column_names, results='hide'}
-dtExample = dbGetQuery(con, "SELECT * FROM read_parquet('../dev/log_parsing/logs/**/*.parquet', union_by_name=true) LIMIT 1")
+log_export_directory = paste0(log_parent_directory, "/logs")
+dtExample = dbGetQuery(
+  con, paste0("SELECT * FROM read_parquet('", 
+              log_export_directory, 
+              "/**/*.parquet', union_by_name=true) LIMIT 1"))
 column_names = names(dtExample)
-column_names[column_names == "client.id"] <- '"client.id" AS client_id' # rename client.id, removing period
-columns_except_id = paste(setdiff(column_names, "id"), collapse = ", ") # remove id column
+# Remove periods from column names
+column_names[column_names == "client.id"] <- '"client.id" AS client_id'
+column_names[column_names == "request.id"] <- '"request.id" AS request_id'
+# Remove id column from earlier processing
+columns_except_id = paste(setdiff(column_names, "id"), collapse = ", ")
 ```
 
 Load parquet data into database file
@@ -65,8 +74,15 @@ if(modifyDB) { dbExecute(con, paste(
 
 Check row count of created table
 
-```{r check_row_count}
-format(dbGetQuery(con, "SELECT COUNT(*) FROM week1")[1,1], big.mark=",")
+```{r check_query_count}
+total_queries = dbGetQuery(con, "SELECT COUNT(*) FROM week1")[1,1]
+cat(paste("Total queries:", format(total_queries, big.mark=",")))
+```
+
+```{r check_granule_query_count}
+granule_queries = dbGetQuery(
+  con, "SELECT COUNT(*) FROM week1 WHERE concept == 'granules'")[1,1]
+cat(paste("Granule queries:", format(granule_queries, big.mark=",")))
 ```
 
 ### Example rows
@@ -91,12 +107,6 @@ There are several attributes of CMR queries that we expect may be relevant to CM
 First, calculate these indicator variables for all the queries in the sample. Then consider their joint presence/absense to group them into broad categories.
 
 ### Spatial boolean
-
-```{r wkt_null_counts, include=FALSE}
-# An unfortunate requirement to print some data frames as HTML tables when knitting the document is enclosing them in parenthesis. Otherwise wrapping with parentheses isn't required.
-(dbGetQuery(con, "SELECT COUNT(*) FROM week1 WHERE wkt IS NULL"))
-(dbGetQuery(con, "SELECT COUNT(*) FROM week1 WHERE wkt IS NOT NULL"))
-```
 
 ```{r spatial_bool, results='hide'}
 if(modifyDB) { 
@@ -141,14 +151,17 @@ Because we don't have the coordiantes for these `r uploaded_shape_count` queries
 dtWKT = dbGetQuery(con, "SELECT wkt, id, geo_type FROM week1")
 setDT(dtWKT)
 dtWKT[, vertex_count := as.integer(count_vertices(wkt))]
-ecdf_fn_vert_count <- ecdf(dtWKT[!is.na(vertex_count), vertex_count])
-dtWKT[!is.na(vertex_count), vertex_pctile := round(ecdf_fn_vert_count(vertex_count), 6), by = vertex_count]
+# Only use POLYGON types in the distribution, otherwise BBOX queries will heavily skew it
+ecdf_fn_vert_count <- ecdf(dtWKT[!is.na(vertex_count) & geo_type == "POLYGON", vertex_count])
+dtWKT[!is.na(vertex_count), 
+      vertex_pctile := round(ecdf_fn_vert_count(vertex_count), 6), 
+      by = vertex_count]
 dtWKT[!is.na(vertex_count), .N, by = .(vertex_count, vertex_pctile)][order(vertex_count)]
 ```
 
 #### Area
 
-```{r duckdb_spatial, include=FALSE}
+```{r duckdb_spatial, results='hide'}
 dbExecute(con, "INSTALL spatial; LOAD spatial")
 ```
 
@@ -162,7 +175,7 @@ if(modifyDB) { dbExecute(con, paste(
 if(modifyDB) { dbExecute(con, paste( 
           "UPDATE week1",
           "SET polygon_area = ST_AREA(ST_GeomFromText(wkt))",
-          "WHERE wkt IS NOT NULL AND geo_type == 'POLYGON'"))}
+          "WHERE wkt IS NOT NULL AND geo_type IN ('BBOX', 'POLYGON')"))}
 ```
 
 ```{r dtAreas}
@@ -172,7 +185,9 @@ setDT(dtAreas)
 
 ```{r ecdf_area}
 ecdf_fn_area <- ecdf(dtAreas$polygon_area)
-dtAreas[!is.na(polygon_area), area_pctile := ecdf_fn_area(polygon_area), by = .(polygon_area)]
+dtAreas[!is.na(polygon_area), 
+        area_pctile := ecdf_fn_area(polygon_area), 
+        by = .(polygon_area)]
 dtAreas[!is.na(polygon_area), .N, by = .(polygon_area, area_pctile)][order(polygon_area)]
 ```
 
@@ -247,14 +262,14 @@ dbGetQuery(con, paste(
 
 ```{r rm_dtWKT}
 # Keep a copy of the vertices for later
-dtVert = dtWKT[!is.na(vertex_count), .(vertex_count)]
+dtVert = dtWKT[!is.na(vertex_count), .(vertex_count, geo_type)]
 # Recover some memory in R
 rm(dtWKT)
 ```
 
 ### Temporal Boolean
 
-```{r temporal_bool, include=FALSE}
+```{r temporal_bool, results='hide'}
 if(modifyDB) { 
   dbExecute(con, paste( 
             "ALTER TABLE week1",
@@ -325,15 +340,15 @@ if(modifyDB) {
   dbExecute(con, paste( 
             "UPDATE week1",
             "SET prov_coll = 'Provider'",
-            "WHERE provider IS NOT NULL AND concept_id IS NULL")) # 7393219
+            "WHERE provider IS NOT NULL AND concept_id IS NULL"))
   dbExecute(con, paste( 
             "UPDATE week1",
             "SET prov_coll = 'Collection'",
-            "WHERE provider IS NULL AND concept_id IS NOT NULL")) # 2651164
+            "WHERE provider IS NULL AND concept_id IS NOT NULL"))
   dbExecute(con, paste( 
             "UPDATE week1",
             "SET prov_coll = 'Both'",
-            "WHERE provider IS NOT NULL AND concept_id IS NOT NULL")) # 4552353
+            "WHERE provider IS NOT NULL AND concept_id IS NOT NULL"))
 }
 ```
 
@@ -356,7 +371,7 @@ if(modifyDB) {
 }
 ```
 
-```{r create_cat1}
+```{r create_cat1, results='hide'}
 if(modifyDB) { 
   dbExecute(con, paste(
     "CREATE OR REPLACE VIEW cat1 AS FROM",
@@ -376,14 +391,18 @@ Example query rows with categorization
 (dbGetQuery(con, "SELECT test_cat, cmr_took, spatial_bool, temporal_bool, sort_bool, sort_count, polygon_area, vertex_count FROM cat1 ORDER BY cmr_took DESC LIMIT 100"))
 ```
 
-Around 3% of rows in this period are missing `cmr-took`. In the future, it may be worthwhile to fill those values with `duration` when it is available (not currently extracted into parquet files by `log_to_table.R`). The two values tend to be very similar.
-
 ```{r dtCatTime}
 dtCatTime = dbGetQuery(con, "SELECT test_cat, cmr_took FROM cat1")
 setDT(dtCatTime)
-dtCatTime = dtCatTime[!is.na(cmr_took)] # 97% of granule query REPORTs include `cmr_took`
+dtCatTime = dtCatTime[!is.na(cmr_took)]
 setkey(dtCatTime, "test_cat")
 ```
+
+```{r missing_cmr_took, include=FALSE}
+missing_cmr_took = dtCatTime[is.na(cmr_took), .N]/dtCatTime[, .N]
+```
+
+Around `r scales::label_percent()(missing_cmr_took)` of rows in this period are missing `cmr_took`. In the future, it may be worthwhile to fill those values with `duration` when it is available (not currently extracted into parquet files by `log_to_table.R`). The two values tend to be very similar.
 
 ### CMR processing time percentiles
 
@@ -431,24 +450,6 @@ Display sorted by the slowest categories (by 95th percentile), descending
 ```{r categories_by_slowest}
 p_cats[order(-p0.95)]
 ```
-
-#### Examine the provider/collection ratio for the slowest category
-
-Does searching by provider possibly explain some of the poor performance of the slowest categories?
-
-`10110` only has 25 rows, so there's not enough data to calculate 95th percentile CMR time by group. We'll use mean and median (50th percentile) for this check.
-
-```{r provider_10110}
-dbGetQuery(con, "SELECT COUNT(*) AS count, prov_coll, AVG(cmr_took) AS mean_cmr_took, MEDIAN(cmr_took) AS 'p0.5' FROM cat1 WHERE test_cat == '10110' GROUP BY prov_coll")
-```
-
-Mean and median are definitely sending different messages. Since this category only has 25 queries, take a look at the information we used to categorize them:
-
-```{r queries_10110}
-dbGetQuery(con, "SELECT test_cat, sort_count, polygon_area, vertex_count, cmr_took, prov_coll FROM cat1 WHERE test_cat == '10110' ORDER BY prov_coll, cmr_took DESC")
-```
-
-The slowest queries do use Providers, but there are proportionally plenty of fast examples, too. We'd have to check which providers they searched and which sorts were requested to get better insight into what made these searches slow. We're not doing that right now; this is just a small enough example to show within the notebook.
 
 ### Current test suite coverage
 
@@ -532,11 +533,12 @@ We have 16 categories in this one week sample of CMR queries. Below is a table o
 p_cats[order(-count)]
 ```
 
-We need to keep in mind some existing realistic query patterns when designing Bigstac. If we were to focus on the top 6 most common categories, they would represent 98.5% of the queries.
-
 ```{r top_six_cats_percentage}
-p_cats[order(-count)][1:6, sum(count)]/p_cats[, sum(count)]
+top_six_percentage = p_cats[order(-count)][1:6, sum(count)]/p_cats[, sum(count)]
+top_six_percentage
 ```
+
+We need to keep in mind some existing realistic query patterns when designing Bigstac. If we were to focus on the top 6 most common categories, they would represent `r scales::label_percent()(top_six_percentage)` of the queries.
 
 ```{r top_size_cats}
 cat6 = p_cats[order(-count)][1:6, test_cat]
@@ -561,7 +563,7 @@ Top 6 categories
 p_cats[test_cat %in% cat6]
 ```
 
-Below are the 4 categories from the benchmark suite that exist in the log data. Note the two most common below are also in the top 6 set above. The other two are quite rare in the log data.
+Below are the 4 categories from the benchmark suite that exist in the log data. Note the most common category below is also in the top 6 set above.
 
 ```{r suite_cats}
 p_cats[test_cat %in% dtSuite8$test_cat]
@@ -766,10 +768,14 @@ area_hist = hist(dtAreas$polygon_area, breaks = area_bins, plot = FALSE)
 dtPlot = as.data.table(list(lower = area_hist$breaks[-length(area_hist$breaks)], 
                             upper = area_hist$breaks[-1],
                             counts = area_hist$counts))
-dtPlot[, bin := paste(conditional_scientific(lower), "-", 
+# Show that bins are right-inclusive in their names
+dtPlot[, bin := paste(conditional_scientific(lower+1), "-", 
+                      conditional_scientific(upper))]
+# Fix the first bin name
+dtPlot[1, bin := paste(conditional_scientific(lower), "-", 
                       conditional_scientific(upper))]
 # Reduce significant digits in maximum label
-dtPlot[upper == max(upper), bin := paste(conditional_scientific(lower), "-", 
+dtPlot[upper == max(upper), bin := paste(conditional_scientific(lower+1), "-", 
                                          format(upper, digits = 3))]
 dtPlot
 ```
@@ -779,7 +785,9 @@ ggplot(dtPlot, aes(x=bin, y=counts)) +
   geom_bar(stat = "identity", fill = "#051399") + 
   # `limits` sets the order, otherwise would be alphabetical
   scale_x_discrete(limits = dtPlot$bin) + 
-  scale_y_continuous(breaks = seq(0,6e+05,2e+05), labels = \(l) format(l, scientific = FALSE, big.mark=',')) + 
+  scale_y_continuous(labels = \(l) format(l, scientific = FALSE, big.mark=',')) + 
+  geom_text(aes(x=bin, y=counts, label = format(counts, big.mark = ',')), 
+          nudge_y = 100000, data = dtPlot[upper >= 1e+08]) + 
   ylab("count") + 
   xlab("Area Bins (m²)") + 
   theme(axis.text.x = element_text(angle = 30, vjust = 1, hjust=1), 
@@ -795,12 +803,12 @@ Includes features of all types: points, lines, polygons, bounding boxes (convert
 As in the polygon area above, I did some experiments to find useful histogram breaks, and then wrote the breaks manually.
 
 ```{r bar_vertex_count}
-vert_bins = c(1,1,2,3,4,5,20,100,200,1000,8000)
+vert_bins = c(1,1,2,3,4,5,20,100,200,1000,max(dtVert$vertex_count))
 vert_hist = hist(dtVert$vertex_count, breaks = vert_bins, plot = FALSE)
 dtPlot = as.data.table(list(lower = vert_hist$breaks[-length(vert_hist$breaks)], 
                             upper = vert_hist$breaks[-1],
                             counts = vert_hist$counts))
-dtPlot[, bin := paste(lower, "-", upper)]
+dtPlot[, bin := paste(lower + 1, "-", upper)]
 dtPlot[1:5, bin := 1:5]
 
 ggplot(dtPlot, aes(x=bin, y=counts)) + 
@@ -814,3 +822,31 @@ ggplot(dtPlot, aes(x=bin, y=counts)) +
   ggtitle("Vertex Count, by Feature", 
           subtitle = paste("First week of October 2024. N =", format(dtVert[, .N], big.mark=',')))
 ```
+
+However, the 5 vertex bin hides the variation seen in the other bins.   
+Below is a table view to better display the variation:
+```{r vertices_table}
+vert_polygon_hist = hist(dtVert[geo_type == "POLYGON", vertex_count], 
+                         breaks = vert_bins, plot = FALSE)
+vert_bbox_hist = hist(dtVert[geo_type == "BBOX", vertex_count], 
+                      breaks = vert_bins, plot = FALSE)
+dtPlot[, polygon_only := vert_polygon_hist$counts]
+dtPlot[, bbox_only := vert_bbox_hist$counts]
+dtPlot[, .(bin, count_all_geom_types = counts, 
+           count_polygon_only = polygon_only,
+           count_bbox_only = bbox_only)]
+```
+#### Explaining Vertex Counts
+
+In this analysis, bounding boxes are considered to have 5 vertices since they are converted to polygons in order to calculate their area. BBOXes represent more than 2/3 of the 5 vertex records.
+
+There are also BBOX type queries with 10 or 15 vertices. These are from when users submitted a list of two or three BBOXes, and are handled in this analysis as if they were multipolygon features for the purposes of area calculation.
+
+Polygons with three vertices are actually a line, if they are valid at all, since the last point is supposed to be the same as the first point. This is all user-submitted data, and is not guaranteed to be valid.
+
+## Session Info
+
+```{r session_info}
+sessionInfo()
+```
+

--- a/cmr_logs_categorizer/categorize_queries.Rmd
+++ b/cmr_logs_categorizer/categorize_queries.Rmd
@@ -587,6 +587,27 @@ ggplot(dtPlot, aes(x=reorder(concept,count), y=count, fill = as.factor(concept))
   coord_flip()
 ```
 
+### Format
+
+```{r bar_format_type}
+dtPlot = dbGetQuery(con, "SELECT format FROM week1")
+setDT(dtPlot)
+dtPlot = dtPlot[, .(count = .N), by = format]
+unique_count = dtPlot[, .N]
+dtPlot = dtPlot[order(-count)]
+ggplot(dtPlot, aes(x=reorder(format,count), y=count, fill = as.factor(format))) + 
+  geom_bar(stat = "identity") + 
+  geom_text(aes(x=reorder(format,count), y=count, label = format(
+    count, big.mark = ',')), nudge_y = 870000) + 
+  scale_y_continuous(expand = c(0.02, 0), limits = c(0,1.05e+07),
+                     labels = \(l) format(l, scientific = FALSE, big.mark=',')) +
+  theme(axis.text.x = element_text(angle = 30, vjust = 1, hjust=1), 
+        legend.position="none", axis.title=element_blank()) + 
+  ggtitle("Format Types", 
+          subtitle = "First week of October 2024. N = 30,694,912") +
+  coord_flip()
+```
+
 ### Method
 
 ```{r bar_method}
@@ -767,7 +788,6 @@ ggplot(dtPlot, aes(x=bin, y=counts)) +
   geom_bar(stat = "identity", fill = "#781399") + 
   # `limits` sets the order, otherwise would be alphabetical
   scale_x_discrete(limits = dtPlot$bin) + 
-  #scale_y_continuous(breaks = seq(0,6e+05,2e+05), labels = \(l) format(l, scientific = FALSE, big.mark=',')) + 
   scale_y_continuous(labels = \(l) format(l, scientific = FALSE, big.mark=',')) + 
   ylab("count") + 
   theme(axis.text.x = element_text(angle = 30, vjust = 1, hjust=1), 

--- a/cmr_logs_categorizer/categorize_queries.Rmd
+++ b/cmr_logs_categorizer/categorize_queries.Rmd
@@ -527,43 +527,46 @@ However, we wouldn't want to exclude this category from consideration during the
 
 ## Selecting Categories of Interest
 
-We have 16 categories in this one week sample of CMR queries. Below is a table of the most common categories.
+We have `r p_cats[, .N]` categories in this one week sample of CMR queries. Below is a table of the most common categories.
 
 ```{r most_common_categories}
 p_cats[order(-count)]
 ```
 
-```{r top_six_cats_percentage}
-top_six_percentage = p_cats[order(-count)][1:6, sum(count)]/p_cats[, sum(count)]
-top_six_percentage
+```{r top_cats_percentage}
+top_count = 6
+top_cats_percentage = p_cats[order(-count)][1:top_count, sum(count)]/p_cats[, sum(count)]
+top_cats_percentage
 ```
 
-We need to keep in mind some existing realistic query patterns when designing Bigstac. If we were to focus on the top 6 most common categories, they would represent `r scales::label_percent()(top_six_percentage)` of the queries.
+We need to keep in mind some existing realistic query patterns when designing Bigstac. If we were to focus on the top `r top_count` most common categories, they would represent `r scales::label_percent()(top_cats_percentage)` of the queries. After the top `r top_count` categories, there is a larger drop in query counts.
 
 ```{r top_size_cats}
-cat6 = p_cats[order(-count)][1:6, test_cat]
-cat6
+top_cats = p_cats[order(-count)][1:top_count, test_cat]
+top_cats
 ```
 
-Which of these are in the current benchmark suite?
+Top `r top_count` categories
 
-```{r top_six_in_suite}
-dtSuite8[test_cat %in% cat6]
+```{r top_cats}
+p_cats[test_cat %in% top_cats]
+```
+### Relative to benchmark suite categories
+
+Which of the top `r top_count` categories are in the current benchmark suite?
+
+```{r top_in_suite}
+dtSuite8[test_cat %in% top_cats]
 ```
 
-Which categories in the benchmark suite are not in the top 6 most common categories?
+Which categories in the benchmark suite are not in the top `r top_count` most common categories?
 
-```{r suite_not_in_top_six}
-dtSuite8[!test_cat %in% cat6]
+```{r suite_not_in_top}
+dtSuite8[!test_cat %in% top_cats]
 ```
+As discussed earlier, 2 of these are categories with both 99th percentile area and vertex counts, which were not observed in the logged queries at all.
 
-Top 6 categories
-
-```{r top6_cats}
-p_cats[test_cat %in% cat6]
-```
-
-Below are the 4 categories from the benchmark suite that exist in the log data. Note the most common category below is also in the top 6 set above.
+Below are the 4 categories from the benchmark suite that exist in the log data. Note the most common category below is also in the top `r top_count` set above.
 
 ```{r suite_cats}
 p_cats[test_cat %in% dtSuite8$test_cat]
@@ -572,7 +575,7 @@ p_cats[test_cat %in% dtSuite8$test_cat]
 ### Density of CMR time by query categories
 
 ```{r cmr_time_density_setup}
-dtCatTimeSub = dtCatTime[test_cat %in% cat6]
+dtCatTimeSub = dtCatTime[test_cat %in% top_cats]
 dtCatTimeSub[, test_cat := as.factor(test_cat)]
 p_dens_cats <- ggplot(dtCatTimeSub, aes(cmr_took, color = test_cat, fill = test_cat))+
   geom_density(alpha = 0.06) +

--- a/cmr_logs_categorizer/count_shapefiles.sh
+++ b/cmr_logs_categorizer/count_shapefiles.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -e
+
+# NOTE: needs full path, not relative path, for input directory
+
+# Check if a directory path is provided as an argument
+if [ $# -eq 0 ]; then
+    echo "Please provide a directory path as an argument."
+    exit 1
+fi
+
+# Check if at least two arguments are provided
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <directory_path> <num_threads>"
+    exit 1
+fi
+
+# Get the directory path from the first argument
+base_dir="$1"
+pwd
+cd $base_dir
+
+# Check if the provided path is a directory
+if [ ! -d "$base_dir" ]; then
+    echo "Error: '$base_dir' is not a valid directory."
+    exit 1
+fi
+
+process_log(){
+  out_filename="$1/shapes"
+  gzcat $2 | \
+    grep cmr.search.services.query-service | \
+    grep '{:shapefile {:filename' >> $out_filename
+}
+
+process_dir() {
+  # Get the dirname from the first argument
+  in_filename="$1"
+
+  # Get array of .gz files in the directory
+  # Initialize an empty array
+  gz_files=()
+
+  # Use while loop to read lines into array
+  while IFS= read -r line; do
+      gz_files+=("$line")
+  done < <(find "$1" -type f -name "*.gz" | sort)
+
+  # Print the number of .gz files found
+  echo "Found ${#gz_files[@]} .gz files"
+
+  # Extract the filename without extension
+  #filename_no_ext="${in_filename%.*}"
+
+  # send filename and dirname-based grep target filename to process_log
+  for file in "${gz_files[@]}"; do
+      echo "Processing: $file"
+      process_log $1 $file
+  done
+}
+
+# Export the function
+export -f process_dir
+export -f process_log
+
+# Loop over all subdirectories
+for dir in "$base_dir"/*/; do
+    if [ -d "$dir" ]; then
+        dir_name=$(basename "$dir")
+        process_dir "$dir_name"
+    fi
+done

--- a/cmr_logs_categorizer/count_shapefiles.sh
+++ b/cmr_logs_categorizer/count_shapefiles.sh
@@ -1,24 +1,38 @@
 #!/bin/bash
 set -e
 
-# NOTE: needs full path, not relative path, for input directory
+# Function to display usage
+show_usage() {
+    echo "This script finds log events of shapefiles being uploaded to CMR."
+    echo
+    echo "The expected file organization is parent_dir/child_dir/000000.gz"
+    echo "For every child directory, the script will search in all .gz files for records"
+    echo "indicating shapefile upload. All identified records from .gz files in the "
+    echo "child directory will be output to parent_dir/child_dir/shapes."
+    echo
+    echo "The directory path should be the full path, not a relative path."
+    echo "Specify count of child directories to be processed at once with Num_threads."
+    echo
+    echo "Usage:   $0 <directory_path> <num_threads>"
+    echo "Example: $0 logsdir 4"
+    echo
+}
 
 # Check if a directory path is provided as an argument
 if [ $# -eq 0 ]; then
-    echo "Please provide a directory path as an argument."
+    show_usage
     exit 1
 fi
 
 # Check if at least two arguments are provided
-if [ $# -lt 2 ]; then
-    echo "Usage: $0 <directory_path> <num_threads>"
+if [ $# -ne 2 ]; then
+    echo "Error: provide exactly two arguments to this script. See usage:\n"
+    show_usage
     exit 1
 fi
 
 # Get the directory path from the first argument
 base_dir="$1"
-pwd
-cd $base_dir
 
 # Check if the provided path is a directory
 if [ ! -d "$base_dir" ]; then
@@ -26,36 +40,43 @@ if [ ! -d "$base_dir" ]; then
     exit 1
 fi
 
+# Set the number of threads
+num_threads=${2}
+
+# Identify shapefile upload records and save to a common file for each child directory
 process_log(){
-  out_filename="$1/shapes"
-  gzcat $2 | \
+  gzcat $1 | \
     grep cmr.search.services.query-service | \
-    grep '{:shapefile {:filename' >> $out_filename
+    grep '{:shapefile {:filename' >> $2
 }
 
 process_dir() {
   # Get the dirname from the first argument
-  in_filename="$1"
+  in_dirname="$1"
+  echo "Processing dir: $in_dirname"
 
   # Get array of .gz files in the directory
   # Initialize an empty array
   gz_files=()
 
-  # Use while loop to read lines into array
+  # Read file search results into array
   while IFS= read -r line; do
       gz_files+=("$line")
   done < <(find "$1" -type f -name "*.gz" | sort)
 
   # Print the number of .gz files found
-  echo "Found ${#gz_files[@]} .gz files"
+  echo "Found ${#gz_files[@]} .gz files in $1"
 
-  # Extract the filename without extension
-  #filename_no_ext="${in_filename%.*}"
+  # Erase previous output to shapes output target
+  out_filename="$1/shapes"
+  if [ -f $out_filename ]; then
+      rm $out_filename
+  fi
 
-  # send filename and dirname-based grep target filename to process_log
+  # Send dirname-based grep output target and gzfilename to process_log
   for file in "${gz_files[@]}"; do
-      echo "Processing: $file"
-      process_log $1 $file
+      echo "Processing file: $file"
+      process_log $file $out_filename
   done
 }
 
@@ -63,10 +84,5 @@ process_dir() {
 export -f process_dir
 export -f process_log
 
-# Loop over all subdirectories
-for dir in "$base_dir"/*/; do
-    if [ -d "$dir" ]; then
-        dir_name=$(basename "$dir")
-        process_dir "$dir_name"
-    fi
-done
+# Run on subdirectories in parallel
+find $1 -type d -maxdepth 1 -iname 'prod-app*' | sort | parallel -j $num_threads -u process_dir

--- a/cmr_logs_categorizer/log_to_table.R
+++ b/cmr_logs_categorizer/log_to_table.R
@@ -141,8 +141,8 @@ dt[is.na(time_query), time_query := melt_time[.SD, facet_date, on = .(id)]]
 
 ## Provider ----
 
-columns_provider = grep('params.provider', ignore.case = TRUE, names(dt), 
-                        value = TRUE)
+columns_provider = grep('^(provider)$|params.provider', ignore.case = TRUE, 
+                        names(dt), value = TRUE)
 dt[, provider := combine_columns_get_nonNA(.SD, columns_provider, TRUE)]
 # Some have additonal parameters after a quote that were not parsed separately
 dt[, provider := str_split_i(provider, '"', 1)]
@@ -155,21 +155,21 @@ dt[str_detect(provider, "[^a-zA-Z0-9_]"), provider := "INVALID"]
 
 ## Sort key ----
 
-columns_sortkey = grep('params.sort_key', ignore.case = TRUE, names(dt),
-                       value = TRUE)
+columns_sortkey = grep('^(sort.key)$|params.sort.key', names(dt), 
+                       ignore.case = TRUE, value = TRUE)
 dt[, sort_key := combine_columns_get_nonNA(.SD, columns_sortkey, TRUE)]
 
 # # XXX CONSIDER FOR REPORT
 # dt[, .N, by = sort_key][order(-N)]
 
 ## Page size page num ----
-columns_page_size = grep('params.(page_size|pageSize)', ignore.case = TRUE, 
-                         names(dt), value = TRUE)
+columns_page_size = grep('^(page.size)$|params.(page.size|pageSize)', 
+                         ignore.case = TRUE, names(dt), value = TRUE)
 dt[, page_size := as.integer(
   combine_columns_get_nonNA(.SD, columns_page_size, TRUE))]
 
-columns_page_num = grep('params.page_num', ignore.case = TRUE, names(dt), 
-                         value = TRUE)
+columns_page_num = grep('^(page.num)$|params.page.num', 
+                        ignore.case = TRUE, names(dt), value = TRUE)
 dt[, page_num := as.integer(
   combine_columns_get_nonNA(.SD, columns_page_num, TRUE))]
 
@@ -178,8 +178,8 @@ dt[, page_num := as.integer(
 # dt[, .N, by = page_num][order(-N)]
 
 ## Version ----
-columns_version = grep('params.version', ignore.case = TRUE, names(dt), 
-                         value = TRUE) # exludes options.version..pattern
+columns_version = grep('^(version)$|params.version', ignore.case = TRUE, 
+                       names(dt), value = TRUE)
 dt[, version := combine_columns_get_nonNA(.SD, columns_version, TRUE)]
 # Some are unintentional user or client app inputs, mark these as INVALID
 dt[# keep strings with Near-Real-Time
@@ -192,15 +192,16 @@ dt[# keep strings with Near-Real-Time
 # dt[, .N, by = version][order(-N)]
 
 ## Short name ----
-columns_short_name = grep('params.short_name', ignore.case = TRUE, names(dt), 
-                        value = TRUE)
+columns_short_name = grep('^(short.name)$|params.short.name', 
+                          ignore.case = TRUE, names(dt), value = TRUE)
 dt[, short_name := combine_columns_get_nonNA(.SD, columns_short_name, TRUE)]
 
 # # XXX CONSIDER FOR REPORT
 # dt[, .N, by = short_name][order(-N)]
 
 ## Concept ID ----
-columns_concept_id = grep(pattern = paste0(c(
+columns_concept_id = grep(pattern = paste(c(
+  '^(concept.id)$',
   'params.collectionConceptId',
   'params.concept.id',
   'params.collection.concept.id',

--- a/cmr_logs_categorizer/log_to_table.R
+++ b/cmr_logs_categorizer/log_to_table.R
@@ -50,9 +50,6 @@ dt[str_detect(concept, 'php'), concept := 'PHP']
 # Remove extensions (formats) from concepts
 dt[str_detect(concept, '\\.'), concept := str_split_i(concept, '\\.', 1)]
 dt[ , format := matchExtension(uri)]
-# # XXX CONSIDER FOR REPORT
-# dt[, .N, by = concept][order(-N)]
-# dt[, .N, by = format][order(-N)]
 
 ## Extract and simplify user agent ----
 dt[, user_agent_type := str_split_i(substr(user.agent,1,80),'/',1)]
@@ -66,20 +63,14 @@ dt[str_detect(user_agent_type, "[P|p]ython|PycURL"), user_agent_type := "Python"
 # TODO: find a package that can better parse user agents to id specific browsers
 dt[str_detect(user_agent_type, "[M|m]ozilla"), 
    user_agent_type := "Web Browser"]
-# # XXX CONSIDER FOR REPORT
-# dt[, .N, by = user_agent_type][order(-N)]
 
 ## Convert cmr.took to numeric type ----
 dt[, cmr_took := as.numeric(cmr.took)]
 # Remove the old version with . in the name to avoid confusion
 dt[, cmr.took := NULL]
-# # XXX CONSIDER FOR REPORT
-# summary(dt$cmr_took)
 
 ## Record whether cmr.search.after was provided ----
 dt[, used_search_after := !is.na(cmr.search.after)]
-# # XXX CONSIDER FOR REPORT
-# dt[, .N, by = used_search_after]
 
 # ///////////////////////////////////////
 # Process temporal queries           ----
@@ -132,9 +123,6 @@ melt_time[str_detect(facet_date, "NA"),
 # Insert dates from facets into the temporal query column where it doesn't already have values
 dt[is.na(time_query), time_query := melt_time[.SD, facet_date, on = .(id)]]
 
-# # XXX CONSIDER FOR REPORT
-# dt[, .N, by = .(has_temporal_query = !is.na(time_query))]
-
 # ///////////////////////////////////////
 # Process form-params & query-params ----
 # ///////////////////////////////////////
@@ -150,17 +138,11 @@ dt[, provider := str_split_i(provider, "'", 1)]
 # Some are unintentional user or client app inputs, mark these as INVALID
 dt[str_detect(provider, "[^a-zA-Z0-9_]"), provider := "INVALID"]
 
-# # XXX CONSIDER FOR REPORT
-# dt[, .N, by = provider][order(-N)]
-
 ## Sort key ----
 
 columns_sortkey = grep('^(sort.key)$|params.sort.key', names(dt), 
                        ignore.case = TRUE, value = TRUE)
 dt[, sort_key := combine_columns_get_nonNA(.SD, columns_sortkey, TRUE)]
-
-# # XXX CONSIDER FOR REPORT
-# dt[, .N, by = sort_key][order(-N)]
 
 ## Page size page num ----
 columns_page_size = grep('^(page.size)$|params.(page.size|pageSize)', 
@@ -173,10 +155,6 @@ columns_page_num = grep('^(page.num)$|params.page.num',
 dt[, page_num := as.integer(
   combine_columns_get_nonNA(.SD, columns_page_num, TRUE))]
 
-# # XXX CONSIDER FOR REPORT
-# dt[, .N, by = page_size][order(-N)]
-# dt[, .N, by = page_num][order(-N)]
-
 ## Version ----
 columns_version = grep('^(version)$|params.version', ignore.case = TRUE, 
                        names(dt), value = TRUE)
@@ -188,16 +166,10 @@ dt[# keep strings with Near-Real-Time
    str_detect(version, regex("[^a-zA-Z0-9_.,]")), 
    version := "INVALID"]
 
-# # XXX CONSIDER FOR REPORT
-# dt[, .N, by = version][order(-N)]
-
 ## Short name ----
 columns_short_name = grep('^(short.name)$|params.short.name', 
                           ignore.case = TRUE, names(dt), value = TRUE)
 dt[, short_name := combine_columns_get_nonNA(.SD, columns_short_name, TRUE)]
-
-# # XXX CONSIDER FOR REPORT
-# dt[, .N, by = short_name][order(-N)]
 
 ## Concept ID ----
 columns_concept_id = grep(pattern = paste(c(
@@ -210,16 +182,10 @@ columns_concept_id = grep(pattern = paste(c(
   names(dt), ignore.case = TRUE, value = TRUE)
 dt[, concept_id := combine_columns_get_nonNA(.SD, columns_short_name, TRUE)]
 
-# # XXX CONSIDER FOR REPORT
-# dt[, .N, by = concept_id][order(-N)]
-
 ## Instrument ----
 columns_instrument = grep('^(instrument)$|params.instrument', ignore.case = TRUE,
                           names(dt), value = TRUE)
 dt[, instrument := combine_columns_get_nonNA(.SD, columns_instrument, TRUE)]
-
-# # XXX CONSIDER FOR REPORT
-# dt[, .N, by = instrument][order(-N)]
 
 # ///////////////////////////////////////
 # Process spatial queries            ----

--- a/cmr_logs_categorizer/log_to_table.R
+++ b/cmr_logs_categorizer/log_to_table.R
@@ -79,10 +79,10 @@ dt[str_detect(user_agent_type, "[P|p]ython|PycURL"), user_agent_type := "Python"
 dt[str_detect(user_agent_type, "[M|m]ozilla"), 
    user_agent_type := "Web Browser"]
 
-## Convert cmr.took to numeric type ----
-dt[, cmr_took := as.numeric(cmr.took)]
-# Remove the old version with . in the name to avoid confusion
-dt[, cmr.took := NULL]
+## Query duration ----
+# cmr.took is missing part of the time. When both cmr.took and duration are both
+# present, their mean difference is around 2ms.
+columns_keep = c(columns_keep, 'duration')
 
 ## Record whether cmr.search.after was provided ----
 dt[, used_search_after := !is.na(cmr.search.after)]

--- a/cmr_logs_categorizer/log_to_table.R
+++ b/cmr_logs_categorizer/log_to_table.R
@@ -37,6 +37,8 @@ dt[, id := .I]
 # Columns to retain that don't need transformed ----
 # Note "now" is a string and would need converted to time for analysis
 columns_keep = c("now", "status", "method", "client.id", "request.id")
+# Also keep URI for debugging purposes; not needed for categorization report
+columns_keep = c(columns_keep, 'uri')
 
 # ///////////////////////////////////////
 # Process root properties            ----

--- a/cmr_logs_categorizer/log_to_table.R
+++ b/cmr_logs_categorizer/log_to_table.R
@@ -67,6 +67,10 @@ dt[str_detect(user_agent_type, "podaac-subscriber"),
 dt[, user_agent_type := str_split_i(user_agent_type, " v[[:digit:]]", 1)]
 dt[str_detect(user_agent_type, "[B|b]ot"), user_agent_type := "Bot"]
 dt[str_detect(user_agent_type, "[P|p]ython|PycURL"), user_agent_type := "Python"]
+# For now, all browser-like user agents will be handled as a single value
+# TODO: find a package that can better parse user agents to id specific browsers
+dt[str_detect(user_agent_type, "[M|m]ozilla"), 
+   user_agent_type := "Web Browser"]
 # # XXX CONSIDER FOR REPORT
 # dt[, .N, by = user_agent_type][order(-N)]
 

--- a/cmr_logs_categorizer/log_to_table.R
+++ b/cmr_logs_categorizer/log_to_table.R
@@ -213,8 +213,8 @@ dt[, concept_id := combine_columns_get_nonNA(.SD, columns_short_name, TRUE)]
 # dt[, .N, by = concept_id][order(-N)]
 
 ## Instrument ----
-columns_instrument = grep('params.instrument', ignore.case = TRUE, names(dt), 
-                          value = TRUE)
+columns_instrument = grep('^(instrument)$|params.instrument', ignore.case = TRUE,
+                          names(dt), value = TRUE)
 dt[, instrument := combine_columns_get_nonNA(.SD, columns_instrument, TRUE)]
 
 # # XXX CONSIDER FOR REPORT

--- a/cmr_logs_categorizer/log_to_table.R
+++ b/cmr_logs_categorizer/log_to_table.R
@@ -2,11 +2,13 @@
 # that are useful for understanding categories of CMR queries.
 # Stores output in tabular format.
 
-library(jsonlite)
-library(data.table)
-library(stringr)
-library(sf)
-library(arrow)
+suppressPackageStartupMessages({
+  library(jsonlite)
+  library(data.table)
+  library(stringr)
+  library(sf)
+  library(arrow)
+})
 
 source('parsing_functions.R')
 
@@ -53,9 +55,9 @@ dt[str_detect(concept, 'php'), concept := 'PHP']
 # Remove extensions (formats) from concepts
 dt[str_detect(concept, '\\.'), concept := str_split_i(concept, '\\.', 1)]
 dt[ , format := matchExtension(uri)]
-# XXX CONSIDER FOR REPORT
-dt[, .N, by = concept][order(-N)]
-dt[, .N, by = format][order(-N)]
+# # XXX CONSIDER FOR REPORT
+# dt[, .N, by = concept][order(-N)]
+# dt[, .N, by = format][order(-N)]
 
 ## Extract and simplify user agent ----
 dt[, user_agent_type := str_split_i(substr(user.agent,1,80),'/',1)]
@@ -65,20 +67,20 @@ dt[str_detect(user_agent_type, "podaac-subscriber"),
 dt[, user_agent_type := str_split_i(user_agent_type, " v[[:digit:]]", 1)]
 dt[str_detect(user_agent_type, "[B|b]ot"), user_agent_type := "Bot"]
 dt[str_detect(user_agent_type, "[P|p]ython|PycURL"), user_agent_type := "Python"]
-# XXX CONSIDER FOR REPORT
-dt[, .N, by = user_agent_type][order(-N)]
+# # XXX CONSIDER FOR REPORT
+# dt[, .N, by = user_agent_type][order(-N)]
 
 ## Convert cmr.took to numeric type ----
 dt[, cmr_took := as.numeric(cmr.took)]
 # Remove the old version with . in the name to avoid confusion
 dt[, cmr.took := NULL]
-# XXX CONSIDER FOR REPORT
-summary(dt$cmr_took)
+# # XXX CONSIDER FOR REPORT
+# summary(dt$cmr_took)
 
 ## Record whether cmr.search.after was provided ----
 dt[, used_search_after := !is.na(cmr.search.after)]
-# XXX CONSIDER FOR REPORT
-dt[, .N, by = used_search_after]
+# # XXX CONSIDER FOR REPORT
+# dt[, .N, by = used_search_after]
 
 # ///////////////////////////////////////
 # Process temporal queries           ----
@@ -131,8 +133,8 @@ melt_time[str_detect(facet_date, "NA"),
 # Insert dates from facets into the temporal query column where it doesn't already have values
 dt[is.na(time_query), time_query := melt_time[.SD, facet_date, on = .(id)]]
 
-# XXX CONSIDER FOR REPORT
-dt[, .N, by = .(has_temporal_query = !is.na(time_query))]
+# # XXX CONSIDER FOR REPORT
+# dt[, .N, by = .(has_temporal_query = !is.na(time_query))]
 
 # ///////////////////////////////////////
 # Process form-params & query-params ----
@@ -149,8 +151,8 @@ dt[, provider := str_split_i(provider, "'", 1)]
 # Some are unintentional user or client app inputs, mark these as INVALID
 dt[str_detect(provider, "[^a-zA-Z0-9_]"), provider := "INVALID"]
 
-# XXX CONSIDER FOR REPORT
-dt[, .N, by = provider][order(-N)]
+# # XXX CONSIDER FOR REPORT
+# dt[, .N, by = provider][order(-N)]
 
 ## Sort key ----
 
@@ -158,8 +160,8 @@ columns_sortkey = grep('params.sort_key', ignore.case = TRUE, names(dt),
                        value = TRUE)
 dt[, sort_key := combine_columns_get_nonNA(.SD, columns_sortkey, TRUE)]
 
-# XXX CONSIDER FOR REPORT
-dt[, .N, by = sort_key][order(-N)]
+# # XXX CONSIDER FOR REPORT
+# dt[, .N, by = sort_key][order(-N)]
 
 ## Page size page num ----
 columns_page_size = grep('params.(page_size|pageSize)', ignore.case = TRUE, 
@@ -172,9 +174,9 @@ columns_page_num = grep('params.page_num', ignore.case = TRUE, names(dt),
 dt[, page_num := as.integer(
   combine_columns_get_nonNA(.SD, columns_page_num, TRUE))]
 
-# XXX CONSIDER FOR REPORT
-dt[, .N, by = page_size][order(-N)]
-dt[, .N, by = page_num][order(-N)]
+# # XXX CONSIDER FOR REPORT
+# dt[, .N, by = page_size][order(-N)]
+# dt[, .N, by = page_num][order(-N)]
 
 ## Version ----
 columns_version = grep('params.version', ignore.case = TRUE, names(dt), 
@@ -187,32 +189,32 @@ dt[# keep strings with Near-Real-Time
    str_detect(version, regex("[^a-zA-Z0-9_.,]")), 
    version := "INVALID"]
 
-# XXX CONSIDER FOR REPORT
-dt[, .N, by = version][order(-N)]
+# # XXX CONSIDER FOR REPORT
+# dt[, .N, by = version][order(-N)]
 
 ## Short name ----
 columns_short_name = grep('params.short_name', ignore.case = TRUE, names(dt), 
                         value = TRUE)
 dt[, short_name := combine_columns_get_nonNA(.SD, columns_short_name, TRUE)]
 
-# XXX CONSIDER FOR REPORT
-dt[, .N, by = short_name][order(-N)]
+# # XXX CONSIDER FOR REPORT
+# dt[, .N, by = short_name][order(-N)]
 
 ## Concept ID ----
 columns_concept_id = grep('params.concept_id|params.collection_concept_id', 
                           ignore.case = TRUE, names(dt), value = TRUE)
 dt[, concept_id := combine_columns_get_nonNA(.SD, columns_short_name, TRUE)]
 
-# XXX CONSIDER FOR REPORT
-dt[, .N, by = concept_id][order(-N)]
+# # XXX CONSIDER FOR REPORT
+# dt[, .N, by = concept_id][order(-N)]
 
 ## Instrument ----
 columns_instrument = grep('params.instrument', ignore.case = TRUE, names(dt), 
                           value = TRUE)
 dt[, instrument := combine_columns_get_nonNA(.SD, columns_instrument, TRUE)]
 
-# XXX CONSIDER FOR REPORT
-dt[, .N, by = instrument][order(-N)]
+# # XXX CONSIDER FOR REPORT
+# dt[, .N, by = instrument][order(-N)]
 
 # ///////////////////////////////////////
 # Process spatial queries            ----

--- a/cmr_logs_categorizer/log_to_table.R
+++ b/cmr_logs_categorizer/log_to_table.R
@@ -1,0 +1,272 @@
+# Given an uncompressed export file of CMR logs, extract and format elements
+# that are useful for understanding categories of CMR queries.
+# Stores output in tabular format.
+
+library(jsonlite)
+library(data.table)
+library(stringr)
+library(sf)
+library(arrow)
+
+source('parsing_functions.R')
+
+# Capture command line arguments
+args <- commandArgs(trailingOnly = TRUE)
+
+# XXX DEBUG
+if(length(args) == 0){
+  args = c('prod-app-047c4bf7c23d46af8346597855880020/000000.json')
+}
+
+# Check if arguments were provided
+if (length(args) != 1) {
+  stop("Must provide path to log data as an argument", call. = FALSE)
+}
+
+# Get full path to prepared log file
+in_full_path = args[1]
+if(!file.exists(in_full_path)) stop(paste(
+  "File", in_full_path, "does not exist."), call. = FALSE)
+
+# Parse path and filename; use these later for writing output
+in_path = dirname(in_full_path)
+in_file = basename(in_full_path)
+
+# Read input file and convert to data.table
+dt = as.data.table(fromJSON(in_full_path), flatten = TRUE)
+# Add row IDs
+dt[, id := .I]
+
+# Columns to retain that don't need transformed ----
+# Note "now" is a string and would need converted to time for analysis
+columns_keep = c("now", "status", "method", "client.id")
+
+# ///////////////////////////////////////
+# Process root properties            ----
+# ///////////////////////////////////////
+
+## Get requested concepts and formats from the URI ----
+
+dt[, concept := getPathByPos(uri, 1)]
+# Group all PHP requests together
+dt[str_detect(concept, 'php'), concept := 'PHP'] 
+# Remove extensions (formats) from concepts
+dt[str_detect(concept, '\\.'), concept := str_split_i(concept, '\\.', 1)]
+dt[ , format := matchExtension(uri)]
+# XXX CONSIDER FOR REPORT
+dt[, .N, by = concept][order(-N)]
+dt[, .N, by = format][order(-N)]
+
+## Extract and simplify user agent ----
+dt[, user_agent_type := str_split_i(substr(user.agent,1,80),'/',1)]
+dt[, user_agent_type := str_split_i(user_agent_type, "\\(", 1)]
+dt[str_detect(user_agent_type, "podaac-subscriber"), 
+   user_agent_type := "podaac-subscriber"]
+dt[, user_agent_type := str_split_i(user_agent_type, " v[[:digit:]]", 1)]
+dt[str_detect(user_agent_type, "[B|b]ot"), user_agent_type := "Bot"]
+dt[str_detect(user_agent_type, "[P|p]ython|PycURL"), user_agent_type := "Python"]
+# XXX CONSIDER FOR REPORT
+dt[, .N, by = user_agent_type][order(-N)]
+
+## Convert cmr.took to numeric type ----
+dt[, cmr_took := as.numeric(cmr.took)]
+# Remove the old version with . in the name to avoid confusion
+dt[, cmr.took := NULL]
+# XXX CONSIDER FOR REPORT
+summary(dt$cmr_took)
+
+## Record whether cmr.search.after was provided ----
+dt[, used_search_after := !is.na(cmr.search.after)]
+# XXX CONSIDER FOR REPORT
+dt[, .N, by = used_search_after]
+
+# ///////////////////////////////////////
+# Process temporal queries           ----
+# ///////////////////////////////////////
+
+## Combine temporal queries to a single column ----
+
+# Columns with trailing '..' can be array versions of parameters, although
+# sometimes they only contain single values. Because they do not always store
+# multiple values, we'll check the column type before processing them
+columns_temporal = c("query.params.temporal", "query.params.temporal..", 
+                     "form.params.temporal", "form.params.temporal..")
+# Column names are hard-coded, but in rare cases may not be present in logs
+columns_temporal = intersect(columns_temporal, names(dt)) 
+
+for(column_name in columns_temporal){
+  column_type = class(dt[, get(column_name)])
+
+  if(column_type == "list"){
+    # for rows with at least one temporal query...
+    dt[sapply(get(column_name), length) > 0, 
+       # copy them to the new "time_query" column...
+       time_query := sapply(  
+         get(column_name), 
+         # combining multiple temporal queries into a single ;-separated string
+         function(x){
+           paste(unlist(x), collapse = ";")
+         })] 
+  } else {
+    # for rows with a temporal query...
+    dt[!is.na(get(column_name)), 
+       # copy them to the new "time_query" column
+       time_query := get(column_name)] 
+  }
+}
+
+## Add temporal facets to time column ----
+columns_temporal_facets = grep("params.temporal_facet.*(year|month|day)",
+                               names(dt), ignore.case = TRUE, value = TRUE)
+
+# Combine the facet columns into a single date column
+melt_time = melt(dt, id.vars='id', 
+                 measure.vars = columns_temporal_facets)[,
+                   .(facet_date = paste(value, collapse = '-')), by = id]
+# Convert literal NA strings to NA value
+melt_time[facet_date == "NA-NA-NA", facet_date := NA_character_]
+# Remove NA portions of the facet date, keeping the year or year and month
+melt_time[str_detect(facet_date, "NA"), 
+          facet_date := str_split_i(facet_date, "-NA", 1)]
+# Insert dates from facets into the temporal query column where it doesn't already have values
+dt[is.na(time_query), time_query := melt_time[.SD, facet_date, on = .(id)]]
+
+# XXX CONSIDER FOR REPORT
+dt[, .N, by = .(has_temporal_query = !is.na(time_query))]
+
+# ///////////////////////////////////////
+# Process form-params & query-params ----
+# ///////////////////////////////////////
+
+## Provider ----
+
+columns_provider = grep('params.provider', ignore.case = TRUE, names(dt), 
+                        value = TRUE)
+dt[, provider := combine_columns_get_nonNA(.SD, columns_provider, TRUE)]
+
+# XXX CONSIDER FOR REPORT
+dt[, .N, by = provider][order(-N)]
+
+## Sort key ----
+
+columns_sortkey = grep('params.sort_key', ignore.case = TRUE, names(dt),
+                       value = TRUE)
+dt[, sort_key := combine_columns_get_nonNA(.SD, columns_sortkey, TRUE)]
+
+# XXX CONSIDER FOR REPORT
+dt[, .N, by = sort_key][order(-N)]
+
+## Page size page num ----
+columns_page_size = grep('params.(page_size|pageSize)', ignore.case = TRUE, 
+                         names(dt), value = TRUE)
+dt[, page_size := as.integer(
+  combine_columns_get_nonNA(.SD, columns_page_size, TRUE))]
+
+columns_page_num = grep('params.page_num', ignore.case = TRUE, names(dt), 
+                         value = TRUE)
+dt[, page_num := as.integer(
+  combine_columns_get_nonNA(.SD, columns_page_num, TRUE))]
+
+# XXX CONSIDER FOR REPORT
+dt[, .N, by = page_size][order(-N)]
+dt[, .N, by = page_num][order(-N)]
+
+## Version ----
+columns_version = grep('params.version', ignore.case = TRUE, names(dt), 
+                         value = TRUE) # exludes options.version..pattern
+dt[, version := combine_columns_get_nonNA(.SD, columns_version, TRUE)]
+
+# XXX CONSIDER FOR REPORT
+dt[, .N, by = version][order(-N)]
+
+## Short name ----
+columns_short_name = grep('params.short_name', ignore.case = TRUE, names(dt), 
+                        value = TRUE)
+dt[, short_name := combine_columns_get_nonNA(.SD, columns_short_name, TRUE)]
+
+# XXX CONSIDER FOR REPORT
+dt[, .N, by = short_name][order(-N)]
+
+## Concept ID ----
+columns_concept_id = grep('params.concept_id|params.collection_concept_id', 
+                          ignore.case = TRUE, names(dt), value = TRUE)
+dt[, concept_id := combine_columns_get_nonNA(.SD, columns_short_name, TRUE)]
+
+# XXX CONSIDER FOR REPORT
+dt[, .N, by = concept_id][order(-N)]
+
+## Instrument ----
+columns_instrument = grep('params.instrument', ignore.case = TRUE, names(dt), 
+                          value = TRUE)
+dt[, instrument := combine_columns_get_nonNA(.SD, columns_instrument, TRUE)]
+
+# XXX CONSIDER FOR REPORT
+dt[, .N, by = instrument][order(-N)]
+
+# ///////////////////////////////////////
+# Process spatial queries            ----
+# ///////////////////////////////////////
+# Note the order that we're processing spatial types below is intentional. Each
+# type will only update the `wkt` values that have not yet been set (are NA). We
+# start with more complex shapes and end with simpler shapes. This means that,
+# for example, if a user submitted both a polygon and a point, we keep only the
+# polygon.
+
+# Initialize `wkt` column with NA values
+dt[, wkt := NA_character_]
+
+## Polygons ----
+columns_polygon = grep('params.polygon', ignore.case = TRUE, names(dt), 
+                       value = TRUE)
+for(this_column in columns_polygon){
+  dt[is.na(wkt), wkt := cmr_to_wkt(get(this_column), geo_type = "POLYGON")]
+}
+
+## Bounding boxes ----
+columns_bbox = grep('bounding.{0,1}box', ignore.case = TRUE, names(dt), value = TRUE)
+for(this_column in columns_bbox){
+  convert_bbox_column(dt, this_column, "wkt")
+}
+
+## Circles ----
+columns_circles = grep('circle', ignore.case = TRUE, names(dt), value = TRUE)
+for(this_column in columns_circles){
+  calculate_circle_columns(dt, this_column, "wkt", "circle_radius")
+}
+
+## Lines ----
+columns_lines = grep('params.line', ignore.case = TRUE, names(dt), value = TRUE)
+for(this_column in columns_lines){
+  dt[is.na(wkt), wkt := cmr_to_wkt(get(this_column), geo_type = "LINESTRING")]
+}
+
+## Points ----
+columns_points = grep('params.point', ignore.case = TRUE, names(dt), 
+                     value = TRUE)
+for(this_column in columns_points){
+  dt[is.na(wkt), wkt := cmr_to_wkt(get(this_column), geo_type = "POINT")]
+}
+
+# Address spatial errors ----
+# `string_to_wkt` writes errors to output, which WKT readers can't handle
+# Move those errors to another column
+dt[str_detect(wkt, "ERROR"), error := wkt]
+dt[str_detect(wkt, "ERROR"), wkt := NA_character_]
+
+# ///////////////////////////////////////
+# Write to file                      ----
+# ///////////////////////////////////////
+# TODO: append to `columns_transformed` throughout the script instead of all at once
+columns_transformed = c("id", "concept", "format", "user_agent_type", "cmr_took",
+                        "used_search_after", "time_query", "provider", "sort_key",
+                        "page_size", "page_num", "version", "short_name", 
+                        "concept_id", "instrument", "wkt", "circle_radius")
+final_columns = c(columns_keep, columns_transformed, "error")
+final_columns = intersect(final_columns, names(dt))
+
+dtSub = dt[, ..final_columns]
+
+out_file_name = paste0(str_split_i(in_file, pattern = "\\.", 1),
+                  ".parquet")
+out_file_full_path = paste(in_path, out_file_name, sep = "/")
+write_parquet(dtSub, out_file_full_path)

--- a/cmr_logs_categorizer/log_to_table.R
+++ b/cmr_logs_categorizer/log_to_table.R
@@ -200,8 +200,13 @@ dt[, short_name := combine_columns_get_nonNA(.SD, columns_short_name, TRUE)]
 # dt[, .N, by = short_name][order(-N)]
 
 ## Concept ID ----
-columns_concept_id = grep('params.concept_id|params.collection_concept_id', 
-                          ignore.case = TRUE, names(dt), value = TRUE)
+columns_concept_id = grep(pattern = paste0(c(
+  'params.collectionConceptId',
+  'params.concept.id',
+  'params.collection.concept.id',
+  'params.echo.collection.id'),
+  collapse = '|'), 
+  names(dt), ignore.case = TRUE, value = TRUE)
 dt[, concept_id := combine_columns_get_nonNA(.SD, columns_short_name, TRUE)]
 
 # # XXX CONSIDER FOR REPORT

--- a/cmr_logs_categorizer/log_to_table.R
+++ b/cmr_logs_categorizer/log_to_table.R
@@ -36,7 +36,7 @@ dt[, id := .I]
 
 # Columns to retain that don't need transformed ----
 # Note "now" is a string and would need converted to time for analysis
-columns_keep = c("now", "status", "method", "client.id")
+columns_keep = c("now", "status", "method", "client.id", "request.id")
 
 # ///////////////////////////////////////
 # Process root properties            ----

--- a/cmr_logs_categorizer/log_to_table.R
+++ b/cmr_logs_categorizer/log_to_table.R
@@ -15,11 +15,6 @@ source('parsing_functions.R')
 # Capture command line arguments
 args <- commandArgs(trailingOnly = TRUE)
 
-# XXX DEBUG
-if(length(args) == 0){
-  args = c('prod-app-047c4bf7c23d46af8346597855880020/000000.json')
-}
-
 # Check if arguments were provided
 if (length(args) != 1) {
   stop("Must provide path to log data as an argument", call. = FALSE)

--- a/cmr_logs_categorizer/parsing_functions.R
+++ b/cmr_logs_categorizer/parsing_functions.R
@@ -39,12 +39,15 @@ getPathByPos <- function(uri, position = 1){
 
 
 #' Combine columns into a single string
-#' 
+#'
 #' @param dt data.table with the columns to combine
-#' @param columns_char a character vector containing names of columns that should be combined
-#' @param first If TRUE, return the first non-NA value. If FALSE, paste all column values into a single string (default: FALSE)
-#' 
-#' @return A character vector representing a column of strings combined from the input columns
+#' @param columns_char a character vector containing names of columns that
+#'   should be combined
+#' @param first If TRUE, return the first non-NA value. If FALSE, paste all
+#'   column values into a single string (default: FALSE)
+#'
+#' @return A character vector representing a column of strings combined from the
+#'   input columns
 combine_columns_get_nonNA <- function(dt, columns_char, first = FALSE){
   dtSub = dt[, ..columns_char]
   # Handle list type columns, combining their values into single strings per row
@@ -135,7 +138,8 @@ cmr_to_wkt <- function(column, geo_type){
 #' @param text CSV string of coordinates in pattern X,Y,X,Y,...
 #' @param geo_type feature type in all capital letters
 #'
-#' @returns a partially-formatted WKT string of the feature (without the geo_type prefix)
+#' @returns a partially-formatted WKT string of the feature (without the
+#'   geo_type prefix)
 string_to_wkt <- function(text, geo_type){
   # Early exit if given NA data
   if(is.na(text)) return(NULL)

--- a/cmr_logs_categorizer/parsing_functions.R
+++ b/cmr_logs_categorizer/parsing_functions.R
@@ -414,3 +414,32 @@ convert_time_column <- function(dt,
   dt[i_condition, (out_column) := eval(in_column)]
   dt[i_condition, (time_type_column) := time_type_value]
 }
+
+
+#' When the input column has a value and the output column is NA, set the output
+#' column to a constant value
+#'
+#' Used for columns that indicate something useful, but whose values we're not
+#' keeping. For example, we may want to know a user queried for orbits without
+#' needing to know which orbit numbers.
+#'
+#' @param dt data.table containing query logs
+#' @param in_column input column we are checking for values
+#' @param out_column output column that will receive constant value
+#' @param out_constant constant value to assign to output column
+set_non_na_values <- function(dt, in_column, out_column, out_constant) {
+  in_column = as.name(in_column)
+  column_class = class(dt[, eval(in_column)])
+  
+  if(column_class == "list"){
+    i_condition = dt[sapply(get(in_column), length) > 0 & is.na(get(out_column)),
+                     which = TRUE]
+  } else if(column_class == "character"){
+    i_condition = dt[!is.na(get(in_column)) & is.na(get(out_column)),
+                     which = TRUE]
+  } else {
+    stop(paste("Unsupported column type", column_class))
+  }
+  dt[i_condition, (out_column) := out_constant]
+}
+

--- a/cmr_logs_categorizer/parsing_functions.R
+++ b/cmr_logs_categorizer/parsing_functions.R
@@ -180,17 +180,23 @@ bbox_to_polygon <- function(column){
   bbox_features = lapply(column, function(value){
     # Inner lapply enables handling lists of multiple bounding boxes per query
     lapply(value, function(v){
-      # Convert CSV string to four numbers
-      bbox_num = as.numeric(str_split_1(v, pattern = ','))
-      # Convert numeric vector to bounding box object
-      bbox = st_bbox(c(
-        xmin = bbox_num[1], 
-        xmax = bbox_num[3], 
-        ymax = bbox_num[4], 
-        ymin = bbox_num[2]), crs = st_crs(4326)
-      )
-      # Return polygon version of bounding box
-      st_as_sfc(bbox)
+      tryCatch({
+        # Convert CSV string to four numbers
+        bbox_num = as.numeric(str_split_1(v, pattern = ','))
+        # Convert numeric vector to bounding box object
+        bbox = st_bbox(c(
+          xmin = bbox_num[1], 
+          xmax = bbox_num[3], 
+          ymax = bbox_num[4], 
+          ymin = bbox_num[2]), crs = st_crs(4326)
+        )
+        # Return polygon version of bounding box
+        st_as_sfc(bbox)
+      },
+      error = function(e){
+        return("ERROR: failed to parse bbox coordinates")
+      })
+
     }
     )
   })

--- a/cmr_logs_categorizer/parsing_functions.R
+++ b/cmr_logs_categorizer/parsing_functions.R
@@ -303,11 +303,15 @@ parsed_circle_values <- function(csv){
     if(len_all_split != 3){
       notice = paste0("ERROR: got ", len_all_split, 
                       " split values instead of expected 3")
-      warning(notice)
-      return(notice)
+      extra_info = paste0(notice, "\n-- input circle CSV was: ", csv, "\n", 
+                          "--   this iteration was: ", x)
+      warning(extra_info)
+      point = notice
+      radius = NA_real_
+    } else {
+      point = paste0("(", all_split[1], " ", all_split[2], ")")
+      radius = all_split[3]
     }
-    point = paste0("(", all_split[1], " ", all_split[2], ")")
-    radius = all_split[3]
     list(point = point, radius = radius)
   })
   if(length(parsed_circles) > 1){

--- a/cmr_logs_categorizer/parsing_functions.R
+++ b/cmr_logs_categorizer/parsing_functions.R
@@ -1,0 +1,318 @@
+# Functions to support log_to_table.R
+
+extensions = c('html', 'json', 'xml', 'echo10', 'iso', 'iso19115', 'dif',
+               'dif10', 'csv', 'atom', 'opendata', 'kml', 'stac', 'native', 
+               'umm-json', 'umm_json')
+extensionExpression = paste0('.', extensions, collapse = '|')
+
+#' Matches the specified data format from the input URI
+#'
+#' @param uri URI string
+#'
+#' @returns string contianing the matched data format
+matchExtension <- function(uri){
+  lastPart = sapply(uri, function(uri){
+    tempCount = str_count(uri, '/')
+    if (is.na(tempCount)) { print(paste("NA for:", uri))}
+    str_split_i(uri, "/", tempCount + 1)})
+  matched = str_match(lastPart, extensionExpression)
+  return(str_split_i(matched, '\\.', 2)) # remove period
+}
+
+
+#' Get the specified portion of an input URI
+#'
+#' @param uri URI string
+#' @param position numeric, the position of the desired portion of the URI
+#'
+#' @returns string of the specified position of the path
+getPathByPos <- function(uri, position = 1){
+  split <- sapply(uri, function(x) {
+    if (str_detect(x, "/search/")){
+      return(str_split_i(x, "/search/", 2))
+    } else {
+      return(x)
+    }
+  })
+  str_split_i(split, "/", position)
+}
+
+
+#' Combine columns into a single string
+#' 
+#' @param dt data.table with the columns to combine
+#' @param columns_char a character vector containing names of columns that should be combined
+#' @param first If TRUE, return the first non-NA value. If FALSE, paste all column values into a single string (default: FALSE)
+#' 
+#' @return A character vector representing a column of strings combined from the input columns
+combine_columns_get_nonNA <- function(dt, columns_char, first = FALSE){
+  dtSub = dt[, ..columns_char]
+  # Handle list type columns, combining their values into single strings per row
+  final_columns = columns_char
+  for (this_column in columns_char){
+    if (class(dtSub[, get(this_column)]) == "list"){
+      new_column = paste0(this_column, "_unlist")
+      dtSub[, (new_column) := sapply(get(this_column), function(x){
+        csv = paste(unlist(x), collapse = ',') 
+        csv[sapply(csv, nchar) == 0] <- NA_character_
+        csv
+      })]
+      final_columns = final_columns[final_columns != this_column]
+      final_columns = c(final_columns, new_column)
+    }
+  }
+  dtSub = dtSub[, ..final_columns]
+  
+  # Combine the columns into a single string per row
+  if (first){
+    strings = apply(dtSub, 1, function(x) first(as.character(na.omit(x))))
+  } else {
+    strings = apply(dtSub, 1, function(x) paste(na.omit(x), collapse = ';'))
+  }
+  
+  # Replace zero length character vectors with NA values
+  strings[sapply(strings, length) == 0] <- NA_character_
+  
+  # Change column from list type to character type
+  if(class(strings) == 'list'){
+    old_len = length(strings)
+    strings <- unlist(strings, recursive = FALSE)
+    new_len = length(strings)
+    if(new_len != old_len) stop(
+      paste("Lengths for combination of", paste(columns_char, collapse = " & "), 
+            "don't match after unlisting"))
+  }
+  strings
+}
+
+
+#' Given a column (list or character type) of coordinates and a geospatial type,
+#' return character vector of WKT
+#'
+#' @param column input column (list or character vector) containing coordinates
+#' @param geo_type one of "POLYGON", "LINESTRING", or "POINT"
+#'
+#' @returns character vector of well-known text (WKT) versions of input geometry
+cmr_to_wkt <- function(column, geo_type){
+  # POLYGON, POINT, LINE
+  if(class(column) == "character"){
+    # Convert every feature to WKT
+    coords = sapply(column, string_to_wkt, geo_type = geo_type,
+                    USE.NAMES = FALSE)
+    # Complete WKT by prefixing the geometry type
+    coords = sapply(coords, function(x){
+      if(is.null(x)) NA_character_ else paste(geo_type, x)
+    })
+  # MULTIPOLYGON, MULTIPOINT
+  } else if (class(column) == "list"){
+    # For every feature...
+    coord_list = lapply(column, function(coord_array){
+      # Convert each ring using `string_to_wkt` individually
+      sapply(coord_array, string_to_wkt, geo_type = geo_type,
+             USE.NAMES = FALSE)
+    })
+    # Combine all rings into one comma separated list prefixed by geometry type
+    coords = sapply(coord_list, 
+                    function(single_feature){
+                      if(length(single_feature) == 0){
+                        return(NA_character_)
+                      } else {
+                        paste0("MULTI", geo_type, " (", 
+                               paste(unlist(single_feature), collapse = ", "), 
+                               ")")
+                      }
+                    })
+  } else {
+    stop(paste("ERROR: column", column, "is", class(column), 
+               "type (not chracter or list)"))
+  }
+  coords
+}
+
+
+#' Given a single string of coordinates and a geospatial type, return WKT
+#'
+#' @param text CSV string of coordinates in pattern X,Y,X,Y,...
+#' @param geo_type feature type in all capital letters
+#'
+#' @returns a partially-formatted WKT string of the feature (without the geo_type prefix)
+string_to_wkt <- function(text, geo_type){
+  # Early exit if given NA data
+  if(is.na(text)) return(NULL)
+  
+  # Split all commas
+  all_split = str_split_1(text, ',')
+  # Make sure there's an even number of elements
+  if(length(all_split)%%2 == 1){
+    return("ERROR: Odd Coordinate Count")
+  } else if("" %in% all_split){
+    return("ERROR: Blank coordinate")
+  }
+  
+  # Retrieve two coordiantes at a time into a new string
+  coordinate_pairs = sapply(1:(length(all_split)/2), function(i){
+    toID = i*2
+    this_pair <- paste(all_split[(toID-1):toID], collapse = " ")
+    this_pair
+  })
+  
+  # Gather coordiante pairs into WKT format
+  if(geo_type == "POLYGON"){
+    paste0("((", paste(coordinate_pairs, collapse = ", "), "))")
+  } else {
+    paste0("(", paste(coordinate_pairs, collapse = ", "), ")")
+  }
+}
+
+
+#' Convert bounding box to polygon as well-known text (WKT)
+#'
+#' @param column input column (list or character vector) containing bounding box
+#'   data
+#'
+#' @returns column (character vector) of WKT values
+bbox_to_polygon <- function(column){
+  # Turn off S2 geometry library to avoid conversion of worldwide bounding boxes
+  # to "POLYGON FULL"
+  initial_s2_state = sf_use_s2()
+  if(initial_s2_state) suppressMessages(sf_use_s2(FALSE))
+  # Run anonymous function on every logged bounding box query
+  bbox_features = lapply(column, function(value){
+    # Inner lapply enables handling lists of multiple bounding boxes per query
+    lapply(value, function(v){
+      # Convert CSV string to four numbers
+      bbox_num = as.numeric(str_split_1(v, pattern = ','))
+      # Convert numeric vector to bounding box object
+      bbox = st_bbox(c(
+        xmin = bbox_num[1], 
+        xmax = bbox_num[3], 
+        ymax = bbox_num[4], 
+        ymin = bbox_num[2]), crs = st_crs(4326)
+      )
+      # Return polygon version of bounding box
+      st_as_sfc(bbox)
+    }
+    )
+  })
+  out_wkt = sapply(bbox_features, function(x){
+    # Convert (multi)polygon versions of bounding boxes to WKT
+    geom_list = st_sfc(unlist(x, recursive = FALSE))
+    if(length(geom_list) > 1){
+      st_as_text(st_combine(geom_list)) # MULTIPOLYGON
+    } else {
+      st_as_text(geom_list) # POLYGON
+    }
+  })
+  if(initial_s2_state) suppressMessages(sf_use_s2(TRUE))
+  # Return character vector of WKT values
+  out_wkt
+}
+
+
+#' Converts a bounding box to WKT and writes it to a column in the data.table by
+#' reference
+#'
+#' @param dt data.table containing bounding box column
+#' @param in_column name of bounding box column
+#' @param out_column name of WKT output column
+#'
+#' @returns copy of the data.table
+convert_bbox_column <- function(dt, in_column, out_column){
+  in_column = as.name(in_column)
+  column_class = class(dt[, eval(in_column)])
+  # Calculate non-missing bounding box WKT values
+  if(column_class == "list"){
+    dt[sapply(get(in_column), length) > 0, (out_column) := bbox_to_polygon(eval(in_column))]
+  } else if(column_class == "character"){
+    dt[!is.na(get(in_column)), (out_column) := bbox_to_polygon(eval(in_column))]
+  } else {
+    stop(paste("Unsupported column type", column_class))
+  }
+}
+
+
+#' Updates a data.table by reference, converting circle queries to points (as
+#' WKT) and radius columns.
+#'
+#' Unlike some other functions in this script, the data.table should NOT be
+#' subset before sending to this function.
+#'
+#' @param dt a data.table to update by reference
+#' @param circle_column string, name of the column containing CMR circle queries
+#' @param out_wkt_column string, name of the column to hold output WKT points
+#' @param out_radius_column string, name of the column to hold output circle
+#'   radii
+calculate_circle_columns <- function(dt, circle_column, out_wkt_column, out_radius_column){
+  circle_column_class = class(dt[, get(circle_column)]) 
+  
+  if(circle_column_class == "list"){
+    i_condition = dt[ , sapply(get(circle_column), length) > 0]
+  } else {
+    i_condition = dt[ , !is.na(get(circle_column))]
+  }
+  circle_values = lapply(dt[i_condition, get(circle_column)], parsed_circle_values)
+  
+  wkt_vec = unlist(circle_values, use.names = FALSE)[names(unlist(
+    circle_values)) == 'point']
+  radius_vec = as.integer(unlist(circle_values, use.names = FALSE)[names(unlist(
+    circle_values)) == 'radius'])
+
+  dt[i_condition, (out_wkt_column) := wkt_vec]
+  dt[i_condition, (out_radius_column) := radius_vec]
+}
+
+
+#' Convert CMR circle query CSV into a WKT point value and a radius.
+#'
+#' If multiple circles are provided, the WKT string returned is a MULTIPOINT
+#' containing the center of every circle. However, only a single radius will be
+#' returned, representing the mean of all circle radii from the input list.
+#'
+#' @param csv string or list of strings containing CMR circle queries (e.g.:
+#'   "-83,40,2000")
+#'
+#' @returns list with "point" (WKT string) and "radius" (numeric) items.
+parsed_circle_values <- function(csv){
+  parsed_circles = lapply(csv, function(x){
+    all_split = str_split_1(x, ',')
+    len_all_split = length(all_split)
+    if(len_all_split != 3){
+      notice = paste0("ERROR: got ", len_all_split, 
+                      " split values instead of expected 3")
+      warning(notice)
+      return(notice)
+    }
+    point = paste0("(", all_split[1], " ", all_split[2], ")")
+    radius = all_split[3]
+    list(point = point, radius = radius)
+  })
+  if(length(parsed_circles) > 1){
+    warning("Multiple circles provided; returning mean radius and aggregated MULTIPOINT feature\n")
+    list(point = paste0("MULTIPOINT (", paste(
+           sapply(parsed_circles, function(x){x[["point"]]}), collapse = ", "), ")"),
+         radius = mean(sapply(parsed_circles, function(x){as.numeric(x[["radius"]])})))
+  } else {
+    list(point = paste("POINT", parsed_circles[[1]][["point"]]), 
+         radius = parsed_circles[[1]][["radius"]])
+  }
+}
+
+
+#' Handy function for previewing contents of multiple data.table columns
+#'
+#' @param dt a data.table
+#' @param column_names a character vector of column names to preview
+DEBUG_columninfo <- function(dt, column_names){
+  for (column in column_names){
+    colclass = class(dt[,get(column)])
+    print(paste(column, "-", colclass))
+    if(colclass == "list"){
+      colValues = dt[!is.na(get(column)), get(column)]
+      colValues[sapply(colValues, length) == 0] <- NA_character_
+      print(paste("  e.g.:", first(na.omit(unlist(colValues)))))
+    } else {
+      print(paste("  e.g.:", dt[!is.na(get(column)), first(get(column))]))
+    }
+  }
+  invisible()
+}

--- a/cmr_logs_categorizer/parsing_functions.R
+++ b/cmr_logs_categorizer/parsing_functions.R
@@ -1,9 +1,9 @@
 # Functions to support log_to_table.R
 
-extensions = c('html', 'json', 'xml', 'echo10', 'iso', 'iso19115', 'dif',
+cmr_extensions = c('html', 'json', 'xml', 'echo10', 'iso', 'iso19115', 'dif',
                'dif10', 'csv', 'atom', 'opendata', 'kml', 'stac', 'native', 
                'umm-json', 'umm_json')
-extensionExpression = paste0('.', extensions, collapse = '|')
+cmr_extension_expression = paste0('.', cmr_extensions, collapse = '|')
 
 #' Matches the specified data format from the input URI
 #'
@@ -15,27 +15,28 @@ matchExtension <- function(uri){
     tempCount = str_count(uri, '/')
     if (is.na(tempCount)) { print(paste("NA for:", uri))}
     str_split_i(uri, "/", tempCount + 1)})
-  matched = str_match(lastPart, extensionExpression)
+  matched = str_match(lastPart, cmr_extension_expression)
   return(str_split_i(matched, '\\.', 2)) # remove period
 }
 
 
-#' Get the specified portion of an input URI
-#'
-#' @param uri URI string
-#' @param position numeric, the position of the desired portion of the URI
-#'
-#' @returns string of the specified position of the path
-getPathByPos <- function(uri, position = 1){
-  split <- sapply(uri, function(x) {
-    if (str_detect(x, "/search/")){
-      return(str_split_i(x, "/search/", 2))
-    } else {
-      return(x)
-    }
-  })
-  str_split_i(split, "/", position)
-}
+# Note the order of endpoints below is important. They are used as a pattern for
+# grepping, and the first match found will be the text that's retained. That
+# means longer strings containing a shorter word should appear in the list
+# before the shorter word.
+cmr_search_endpoints = c(
+  "granules/timeline", "granules", "csw/collections", "collections",
+  "provider_holdings", "autocomplete", "concepts", "humanizers", "tiles",
+  "keywords", "tags", "variables", "legacy-services", "services", "tools",
+  "subscriptions", "order-option-drafts", "grid-drafts", "variable-drafts",
+  "grids", "data-quality-summary-drafts", "tool-drafts", "order-options",
+  "data-quality-summaries", "collection-drafts", "service-drafts",
+  "community-usage-metrics", "associate", "health", "clear-cache", "caches", 
+  "clear-scroll", "browse-scaler", "site/collections/directory", "site/docs", 
+  "site/"
+)
+cmr_endpoints_expression = paste0(
+  '/search/', cmr_search_endpoints, collapse = '|')
 
 
 #' Combine columns into a single string

--- a/cmr_logs_categorizer/parsing_functions.R
+++ b/cmr_logs_categorizer/parsing_functions.R
@@ -238,9 +238,11 @@ convert_bbox_column <- function(dt,
   column_class = class(dt[, eval(in_column)])
   # Calculate non-missing bounding box WKT values
   if(column_class == "list"){
-    i_condition = dt[sapply(get(in_column), length) > 0 & is.na(out_column), which = TRUE]
+    i_condition = dt[sapply(get(in_column), length) > 0 & is.na(get(out_column)),
+                     which = TRUE]
   } else if(column_class == "character"){
-    i_condition = dt[!is.na(get(in_column)) & is.na(out_column), which = TRUE]
+    i_condition = dt[!is.na(get(in_column)) & is.na(get(out_column)),
+                     which = TRUE]
   } else {
     stop(paste("Unsupported column type", column_class))
   }

--- a/cmr_logs_categorizer/sum_shapes.sh
+++ b/cmr_logs_categorizer/sum_shapes.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+show_usage() {
+    echo "Sums the total line (query) count of all `shapes` files in subdirectories of the specified parent directory."
+}
+
+if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+    show_usage
+    exit 1
+fi
+
+if [ $# -ne 1 ]; then
+    echo "Error: specify parent directory containing subdirectories with `shapes` files output by `count_shapefiles.sh`"
+    exit 1
+fi
+
+find $1 -iname 'shapes' -exec wc -l "{}" \; | awk '{sum+=$1}END{print sum}'


### PR DESCRIPTION
This workflow:

1. exports CMR query logs to S3
2. downloads them
3. processes selected query parameters into parquet format
4. identifies shapefile uploads
5. categorizes CMR queries in a report rendered to HTML

The main goal is the output of the final step: identifying broad categories of existing CMR queries that are targets for performance optimization and design of Bigstac implementations.

This workflow is implemented in R, shell scripts, and common shell programs.

See `cmr_logs_categorizer/README.md` for details on these steps and how to run them.