### PR TITLE
CMR-10338: Distribute a metadata query over multiple DuckDB clients

### DIFF
--- a/distributed/README.md
+++ b/distributed/README.md
@@ -1,0 +1,20 @@
+# Deploy Distributed DuckDB on Dask
+
+## Prepare CDK environment
+
+Install CDK if you need it:
+```bash
+npm install -g aws-cdk
+```
+
+Set up Python virtual environment
+```bash
+python -m venv cdk_venv
+source cdk_venv/bin/activate
+pip install aws-cdk-lib constructs boto3
+```
+
+## Deploy AWS security group for Dask scheduler and workers
+```bash
+cdk deploy --app "python cdk_dask_sg.py"
+```

--- a/distributed/README.md
+++ b/distributed/README.md
@@ -21,6 +21,21 @@ Edit the `profile_name` in `cdk_dask_sg.py` if necessary. It get credentials fro
 cdk deploy --app "python cdk_dask_sg.py"
 ```
 
+## Create AMI for Dask Cluster
+
+The default VM image for Dask Cloud Provider is Ubuntu 20.04. Cloud Provider recommends using [Packer](https://developer.hashicorp.com/packer) to prepare alternative images. That allows us to base the image on a NGAP-compliant Amazon Linux 2023 AMI, as well as save time by performing setup now (like installing Docker and pulling the image), and not when the cluster is being deployed.
+
+To create the AMI:
+
+1. [Install Packer](https://developer.hashicorp.com/packer/install)
+2. Edit `run_packer.sh` to refer to your AWS profile name from `~/.aws/credentials`.
+3. Run `run_packer.sh`
+  - Expect it to take around 15 minutes.
+
+The **Start Cluster** section of the example notebook specifies the AMI id from the previous run of this Packer step. You can use that AMI and skip running Packer this time. If you do run this Packer step, make sure to update the `ami` parameter to `EC2Cluster` in the notebook with the output AMI id from Packer.
+
+The Packer workflow needs to find the base NGAP-provided AMI, and that requires the AMI's owner ID. That is stored (in CMR SIT) in secrets manager, and is pulled in by `query_AWS_for_packer.py`. The owner ID is unlikely to change. However, the base AMI will need to be updated in the future. That name should be updated in `al2023-docker-dask.pkr.hcl`, replacing `edc-app-base-25.1.3.0-al2023-x86_64` with the name of the newer base AMI.
+
 ## Run Example Notebook
 
 `distributed_duckdb_example.ipynb` prepares a Dask cluster, then runs a DuckDB query. First it runs the query on the Dask cluster, leveraging data parallelism so that each of the two nodes has a different subset of the total data to query. Then it runs the same query on the Jupyter server, which is the same EC2 instance type as the Dask workers. For the test dataset with 17m rows, it is between 33% and 50% faster using the two node Dask cluser. For this test, the data is located on EFS (Amazon's NFS product).

--- a/distributed/README.md
+++ b/distributed/README.md
@@ -1,4 +1,4 @@
-# Deploy Distributed DuckDB on Dask
+# Distributed DuckDB on Dask
 
 ## Prepare CDK environment
 
@@ -15,6 +15,12 @@ pip install aws-cdk-lib constructs boto3
 ```
 
 ## Deploy AWS security group for Dask scheduler and workers
+
+Edit the `profile_name` in `cdk_dask_sg.py` if necessary. It get credentials from `~/.aws/credentials`.
 ```bash
 cdk deploy --app "python cdk_dask_sg.py"
 ```
+
+## Run Example Notebook
+
+`distributed_duckdb_example.ipynb` prepares a Dask cluster, then runs a DuckDB query. First it runs the query on the Dask cluster, leveraging data parallelism so that each of the two nodes has a different subset of the total data to query. Then it runs the same query on the Jupyter server, which is the same EC2 instance type as the Dask workers. For the test dataset with 17m rows, it is between 33% and 50% faster using the two node Dask cluser. For this test, the data is located on EFS (Amazon's NFS product).

--- a/distributed/al2023-docker-dask.pkr.hcl
+++ b/distributed/al2023-docker-dask.pkr.hcl
@@ -1,0 +1,69 @@
+packer {
+  required_plugins {
+    amazon = {
+      version = ">= 1.0.0"
+      source  = "github.com/hashicorp/amazon"
+    }
+  }
+}
+
+variable "ami_owner_id" {
+  type    = string
+  default = ""
+}
+
+variable "vpc_id" {
+  type    = string
+  default = ""
+}
+
+variable "subnet_id" {
+  type    = string
+  default = ""
+}
+
+source "amazon-ebs" "al2023-docker-dask" {
+  ami_name      = "al2023-docker-dask-{{timestamp}}"
+  instance_type = "t3.medium"
+  region        = "us-east-1"
+  vpc_id        = var.vpc_id
+  subnet_id     = var.subnet_id
+  source_ami_filter {
+    filters = {
+      name                = "edc-app-base-25.1.3.0-al2023-x86_64"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    most_recent = true
+    owners      = [var.ami_owner_id]
+  }
+  ssh_username = "ec2-user"
+  ssh_interface = "session_manager"
+  communicator = "ssh"
+  iam_instance_profile = "Packer-SSM-role"
+}
+
+build {
+  name = "amazon-linux-2023-docker-dask"
+  sources = [
+    "source.amazon-ebs.al2023-docker-dask"
+  ]
+
+  provisioner "shell" {
+    remote_folder = "/home/ec2-user"
+    inline = [
+      "sudo dnf update -y",
+      "sudo dnf install -y docker",
+      "sudo systemctl enable docker",
+      "sudo systemctl start docker",
+      "sudo usermod -aG docker ec2-user",
+      "sudo docker pull daskdev/dask:latest",
+      "sudo mkdir /mnt/efs"
+    ]
+  }
+
+  post-processor "manifest" {
+    output = "manifest.json"
+    strip_path = true
+  }
+}

--- a/distributed/cdk_dask_sg.py
+++ b/distributed/cdk_dask_sg.py
@@ -64,7 +64,7 @@ app = App()
 DaskSecurityGroupStack(
     app,
     "DaskSecurityGroupStack",
-    security_group_name="sg_dask",
+    security_group_name="bigstac-dask",
     vpc_id=vpc_id,
     env=Environment(account=account, region=region),
 )

--- a/distributed/cdk_dask_sg.py
+++ b/distributed/cdk_dask_sg.py
@@ -1,0 +1,72 @@
+from aws_cdk import App, aws_ec2 as ec2, Environment, Stack, Tags
+import boto3
+from constructs import Construct
+
+
+class DaskSecurityGroupStack(Stack):
+
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        security_group_name: str,
+        vpc_id: str,
+        **kwargs
+    ) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+
+        # Create the security group
+        security_group = ec2.SecurityGroup(
+            self,
+            "DaskSecurityGroup",
+            security_group_name=security_group_name,
+            description="Security group for Dask",
+            allow_all_outbound=True,  # Allow all outbound traffic for IPv4
+            vpc=ec2.Vpc.from_lookup(self, "VPC", vpc_id=vpc_id),
+        )
+
+        # Add inbound rules for TCP 8786-8787 (IPv4 and IPv6)
+        security_group.add_ingress_rule(
+            ec2.Peer.any_ipv4(),
+            ec2.Port.tcp_range(8786, 8787),
+            "Allow inbound TCP 8786-8787 (IPv4)",
+        )
+        security_group.add_ingress_rule(
+            ec2.Peer.any_ipv6(),
+            ec2.Port.tcp_range(8786, 8787),
+            "Allow inbound TCP 8786-8787 (IPv6)",
+        )
+
+        # Add inbound rule for All TCP 0-65535
+        security_group.add_ingress_rule(
+            ec2.Peer.any_ipv4(),
+            ec2.Port.tcp_range(0, 65535),
+            "Allow all inbound TCP (IPv4)",
+        )
+
+        # Tag the security group
+        Tags.of(security_group).add("Name", security_group_name)
+        Tags.of(security_group).add("Project", "bigstac")
+
+        # Output the security group ID
+        self.sg_id = security_group.security_group_id
+
+
+# Get account, region, and first VPC from the specified profile
+session = boto3.Session(profile_name="cmr-sit")
+account = session.client("sts").get_caller_identity()["Account"]
+region = session.region_name
+ec2_client = session.client("ec2", region_name=region)
+vpc_id = ec2_client.describe_vpcs()["Vpcs"][0]["VpcId"]
+
+# Create stack for the security group
+app = App()
+DaskSecurityGroupStack(
+    app,
+    "DaskSecurityGroupStack",
+    security_group_name="sg_dask",
+    vpc_id=vpc_id,
+    env=Environment(account=account, region=region),
+)
+
+app.synth()

--- a/distributed/distributed_duckdb_example.ipynb
+++ b/distributed/distributed_duckdb_example.ipynb
@@ -232,7 +232,7 @@
     "aws_profile_name = \"cmr-sit-johnathan\"  # change to your profile name\n",
     "efs_name = \"bigstac-duckdb-01\"  # pre-created\n",
     "sg_name_efs = \"bigstac-nfs\"  # pre-created\n",
-    "sg_name_dask = \"sg_dask\"  # specified in cdk_dask_sg.py\n",
+    "sg_name_dask = \"bigstac-dask\"  # specified in cdk_dask_sg.py\n",
     "ssh_key_name = \"bigstac-johnathan\"  # pre-created"
    ]
   },
@@ -317,7 +317,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "NFS rule with description 'from Dask EC2Cluster' already exists in security group sg-\n"
+      "Added NFS inbound rule to security group sg-\n"
      ]
     }
    ],

--- a/distributed/distributed_duckdb_example.ipynb
+++ b/distributed/distributed_duckdb_example.ipynb
@@ -1,0 +1,819 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Distributed DuckDB on Dask\n",
+    "\n",
+    "Set up a Dask cluster on EC2 to process data parallel DuckDB operations. The same query will be sent to every worker, with each worker querying different parquet files."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook should run on a dedicated Jupyter notebook server, and will serve as the Dask **Client**. We will use the Dask Cloud Provider module to launch a cluster on EC2, which will be composed of a **Scheduler** instance and multiple **Worker** instances.\n",
+    "\n",
+    "The client (where this notebook is running) issues commands to the scheduler, and the scheduler distributes the work to the workers.\n",
+    "\n",
+    "The Dask web dashboard runs on the scheduler, not the client. To access it, a separate tunnel from your localhost to the scheduler on port 8787 could be created. This can be useful for understanding Dask scheduling and performance. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "from botocore.exceptions import ClientError\n",
+    "import configparser\n",
+    "import contextlib\n",
+    "from dask_cloudprovider.aws import EC2Cluster\n",
+    "from dask.distributed import Client\n",
+    "import duckdb\n",
+    "import os\n",
+    "import pandas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Utility Functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# based on function of the same name from:\n",
+    "# https://cloudprovider.dask.org/en/latest/aws.html#elastic-compute-cloud-ec2\n",
+    "\n",
+    "\n",
+    "def get_aws_credentials(\n",
+    "    profile, config_path=\"~/.aws/config\", creds_path=\"~/.aws/credentials\"\n",
+    "):\n",
+    "    \"\"\"Read in your AWS credentials file and convert to environment variables.\"\"\"\n",
+    "    parser = configparser.RawConfigParser()\n",
+    "\n",
+    "    if config_path != \"\":\n",
+    "        parser.read(os.path.expanduser())\n",
+    "        config = parser.items(\"default\")\n",
+    "    else:\n",
+    "        config = []\n",
+    "\n",
+    "    if creds_path != \"\":\n",
+    "        parser.read(os.path.expanduser(creds_path))\n",
+    "        credentials = parser.items(profile)\n",
+    "    else:\n",
+    "        credentials = []\n",
+    "\n",
+    "    all_credentials = {key.upper(): value for key, value in [*config, *credentials]}\n",
+    "    with contextlib.suppress(KeyError):\n",
+    "        all_credentials[\"AWS_REGION\"] = all_credentials.pop(\"REGION\")\n",
+    "\n",
+    "    return all_credentials"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Functions to get the IDs of an EFS volume, Security Group, and VPC."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_efs_id_by_name(efs_name, session):\n",
+    "    client = session.client(\"efs\", region_name=\"us-east-1\")\n",
+    "\n",
+    "    response = client.describe_file_systems()\n",
+    "\n",
+    "    for file_system in response[\"FileSystems\"]:\n",
+    "        if \"Name\" in file_system and file_system[\"Name\"] == efs_name:\n",
+    "            return file_system[\"FileSystemId\"]\n",
+    "\n",
+    "    return None\n",
+    "\n",
+    "\n",
+    "def get_sg_id_by_name(sg_name, session, vpc_id):\n",
+    "    client = session.client(\"ec2\")\n",
+    "\n",
+    "    response = client.describe_security_groups(\n",
+    "        Filters=[\n",
+    "            {\"Name\": \"group-name\", \"Values\": [sg_name]},\n",
+    "            {\"Name\": \"vpc-id\", \"Values\": [vpc_id]},\n",
+    "        ]\n",
+    "    )\n",
+    "\n",
+    "    return response[\"SecurityGroups\"][0][\"GroupId\"]\n",
+    "\n",
+    "\n",
+    "# For this particular account, there is not a 'default' VPC, which would\n",
+    "# normally be used by Dask Cloud Provider. But there is a single VPC, so we get\n",
+    "# it by the 0th index.\n",
+    "def get_vpc_id(session):\n",
+    "    client = session.client(\"ec2\")\n",
+    "    vpc_id = client.describe_vpcs()[\"Vpcs\"][0][\"VpcId\"]\n",
+    "    return vpc_id"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The security group used by the EFS volume needs a rule added that allows the instances Dask will create to use it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def add_nfs_rule_to_security_group(\n",
+    "    session, vpc_id, security_group_id, source_security_group_id, description\n",
+    "):\n",
+    "    \"\"\"\n",
+    "    Add an inbound rule to allow NFS connections from a specified security group.\n",
+    "\n",
+    "    :param session: boto3 session\n",
+    "    :param vpc_id: ID of the VPC\n",
+    "    :param security_group_id: ID of the security group to modify\n",
+    "    :param source_security_group_id: ID of the source security group\n",
+    "    :param description: text description of inbound rule\n",
+    "    \"\"\"\n",
+    "    ec2 = session.client(\"ec2\")\n",
+    "\n",
+    "    try:\n",
+    "        # Get the security group\n",
+    "        response = ec2.describe_security_groups(\n",
+    "            Filters=[\n",
+    "                {\"Name\": \"vpc-id\", \"Values\": [vpc_id]},\n",
+    "                {\"Name\": \"group-id\", \"Values\": [security_group_id]},\n",
+    "            ]\n",
+    "        )\n",
+    "\n",
+    "        if not response[\"SecurityGroups\"]:\n",
+    "            print(f\"Security group {security_group_id} not found in VPC {vpc_id}\")\n",
+    "            return\n",
+    "\n",
+    "        security_group = response[\"SecurityGroups\"][0]\n",
+    "\n",
+    "        # Check if the rule already exists\n",
+    "        rule_exists = any(\n",
+    "            rule.get(\"IpProtocol\") == \"tcp\"\n",
+    "            and rule.get(\"FromPort\") == 2049\n",
+    "            and rule.get(\"ToPort\") == 2049\n",
+    "            and any(\n",
+    "                pair.get(\"GroupId\") == source_security_group_id\n",
+    "                and pair.get(\"Description\") == description\n",
+    "                for pair in rule.get(\"UserIdGroupPairs\", [])\n",
+    "            )\n",
+    "            for rule in security_group.get(\"IpPermissions\", [])\n",
+    "        )\n",
+    "\n",
+    "        if rule_exists:\n",
+    "            print(\n",
+    "                f\"NFS rule with description '{description}' already exists in security group {security_group_id}\"\n",
+    "            )\n",
+    "            return\n",
+    "\n",
+    "        # Add the inbound rule\n",
+    "        ec2.authorize_security_group_ingress(\n",
+    "            GroupId=security_group_id,\n",
+    "            IpPermissions=[\n",
+    "                {\n",
+    "                    \"IpProtocol\": \"tcp\",\n",
+    "                    \"FromPort\": 2049,\n",
+    "                    \"ToPort\": 2049,\n",
+    "                    \"UserIdGroupPairs\": [\n",
+    "                        {\n",
+    "                            \"GroupId\": source_security_group_id,\n",
+    "                            \"Description\": description,\n",
+    "                        }\n",
+    "                    ],\n",
+    "                }\n",
+    "            ],\n",
+    "        )\n",
+    "\n",
+    "        print(f\"Added NFS inbound rule to security group {security_group_id}\")\n",
+    "\n",
+    "    except ClientError as e:\n",
+    "        if e.response[\"Error\"][\"Code\"] == \"InvalidPermission.Duplicate\":\n",
+    "            print(\n",
+    "                f\"NFS rule for cluster access already exists in EFS security group {security_group_id}, but with a different description. Did not add new rule.\"\n",
+    "            )\n",
+    "        else:\n",
+    "            print(f\"Error: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Global Parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aws_profile_name = \"cmr-sit-johnathan\"  # change to your profile name\n",
+    "efs_name = \"bigstac-duckdb-01\"  # pre-created\n",
+    "sg_name_efs = \"bigstac-nfs\"  # pre-created\n",
+    "sg_name_dask = \"sg_dask\"  # specified in cdk_dask_sg.py\n",
+    "ssh_key_name = \"bigstac-johnathan\"  # pre-created"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get Credentials"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Credentials should be placed in `~/.aws/credentials`. Recommend the use of short term keys.  \n",
+    "You can use Jupyterlab to open a terminal, create the file and paste your credentials into it.  \n",
+    "Set `aws_profile_name` above to the value of your profile stored in the credentials file.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "creds = get_aws_credentials(aws_profile_name, \"\")\n",
+    "# Create boto3 session for functions that will accept it\n",
+    "session = boto3.Session(\n",
+    "    region_name=\"us-east-1\",\n",
+    "    aws_access_key_id=creds[\"AWS_ACCESS_KEY_ID\"],\n",
+    "    aws_secret_access_key=creds[\"AWS_SECRET_ACCESS_KEY\"],\n",
+    "    aws_session_token=creds[\"AWS_SESSION_TOKEN\"],\n",
+    ")\n",
+    "\n",
+    "# Launching the EC2Cluster relies on instance profile permissions, credentials\n",
+    "# in the \"default\" profile, or environment variables. We'll use the latter:\n",
+    "os.environ[\"AWS_ACCESS_KEY_ID\"] = creds[\"AWS_ACCESS_KEY_ID\"]\n",
+    "os.environ[\"AWS_SECRET_ACCESS_KEY\"] = creds[\"AWS_SECRET_ACCESS_KEY\"]\n",
+    "os.environ[\"AWS_SESSION_TOKEN\"] = creds[\"AWS_SESSION_TOKEN\"]\n",
+    "os.environ[\"AWS_REGION\"] = creds[\"AWS_REGION\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Start Cluster"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Get resource IDs from our AWS account"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vpc_id = get_vpc_id(session)\n",
+    "efs_id = get_efs_id_by_name(efs_name, session)\n",
+    "nfs_sg_id = get_sg_id_by_name(sg_name_efs, session, vpc_id)\n",
+    "cluster_sg_id = get_sg_id_by_name(sg_name_dask, session, vpc_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create a rule that allows the Dask instances to mount the EFS volume"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NFS rule with description 'from Dask EC2Cluster' already exists in security group sg-\n"
+     ]
+    }
+   ],
+   "source": [
+    "rule_description = \"from Dask EC2Cluster\"\n",
+    "add_nfs_rule_to_security_group(\n",
+    "    session, vpc_id, nfs_sg_id, cluster_sg_id, rule_description\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Configure the Dask-managed instances to mount the EFS volume. These additional bootstrapping commands will be run by cloud-init after the default commands created by Dask Cloud Provider."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bootstrap_script = [\n",
+    "    \"mkdir -p /mnt/efs\",\n",
+    "    \"apt-get install nfs-common -y\",\n",
+    "    f\"mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport {efs_id}.efs.us-east-1.amazonaws.com:/ /mnt/efs\",\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Bind mount the EFS volume into the Docker container that will run the Dask scheduler and workers. Also install some extra necessary packages with `pip`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "docker_args = (\n",
+    "    \"--mount type=bind,src=/mnt/efs,dst=/mnt/efs,ro \"\n",
+    "    '-e EXTRA_PIP_PACKAGES=\"duckdb pyarrow\"'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Start the cluster. This will take a couple of minutes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating scheduler instance\n",
+      "Created instance i-0d190df1b812ce655 as dask-eda6680f-scheduler\n",
+      "Waiting for scheduler to run at 10.5.45.35:8786\n",
+      "Scheduler is running\n",
+      "Creating worker instance\n",
+      "Creating worker instance\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/ssm-user/.pyenv/versions/3.10.12/lib/python3.10/contextlib.py:142: UserWarning: Creating your cluster is taking a surprisingly long time. This is likely due to pending resources. Hang tight! \n",
+      "  next(self.gen)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created instance i-015d9a6692c3c8a47 as dask-eda6680f-worker-b8542521\n",
+      "Created instance i-08a9996da6e441243 as dask-eda6680f-worker-3802ecce\n"
+     ]
+    }
+   ],
+   "source": [
+    "cluster = EC2Cluster(\n",
+    "    n_workers=2,\n",
+    "    scheduler_instance_type=\"c5.xlarge\",\n",
+    "    worker_instance_type=\"c5.xlarge\",\n",
+    "    # One thread per worker ensures tasks get split across multiple workers\n",
+    "    worker_options={\"nthreads\": 1, \"memory_limit\": \"7GiB\"},\n",
+    "    # debug=True,\n",
+    "    key_name=ssh_key_name,\n",
+    "    region=creds[\"AWS_REGION\"],\n",
+    "    vpc=vpc_id,\n",
+    "    security_groups=[cluster_sg_id],\n",
+    "    extra_bootstrap=bootstrap_script,\n",
+    "    docker_args=docker_args,\n",
+    "    # Default expects public IPs\n",
+    "    use_private_ip=True,\n",
+    "    # TLS doesn't currently work: https://github.com/dask/dask-cloudprovider/issues/249\n",
+    "    security=False,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"jp-RenderedHTMLCommon jp-RenderedHTML jp-mod-trusted jp-OutputArea-output\">\n",
+       "    <div style=\"width: 24px; height: 24px; background-color: #e1e1e1; border: 3px solid #9D9D9D; border-radius: 5px; position: absolute;\">\n",
+       "    </div>\n",
+       "    <div style=\"margin-left: 48px;\">\n",
+       "        <h3 style=\"margin-bottom: 0px; margin-top: 0px;\">EC2Cluster</h3>\n",
+       "        <p style=\"color: #9D9D9D; margin-bottom: 0px;\">83565f96</p>\n",
+       "        <table style=\"width: 100%; text-align: left;\">\n",
+       "            <tr>\n",
+       "                <td style=\"text-align: left;\">\n",
+       "                    <strong>Dashboard:</strong> <a href=\"http://10.5.45.35:8787/status\" target=\"_blank\">http://10.5.45.35:8787/status</a>\n",
+       "                </td>\n",
+       "                <td style=\"text-align: left;\">\n",
+       "                    <strong>Workers:</strong> 2\n",
+       "                </td>\n",
+       "            </tr>\n",
+       "            <tr>\n",
+       "                <td style=\"text-align: left;\">\n",
+       "                    <strong>Total threads:</strong> 2\n",
+       "                </td>\n",
+       "                <td style=\"text-align: left;\">\n",
+       "                    <strong>Total memory:</strong> 14.00 GiB\n",
+       "                </td>\n",
+       "            </tr>\n",
+       "            \n",
+       "        </table>\n",
+       "\n",
+       "        <details>\n",
+       "            <summary style=\"margin-bottom: 20px;\">\n",
+       "                <h3 style=\"display: inline;\">Scheduler Info</h3>\n",
+       "            </summary>\n",
+       "\n",
+       "            <div style=\"\">\n",
+       "    <div>\n",
+       "        <div style=\"width: 24px; height: 24px; background-color: #FFF7E5; border: 3px solid #FF6132; border-radius: 5px; position: absolute;\"> </div>\n",
+       "        <div style=\"margin-left: 48px;\">\n",
+       "            <h3 style=\"margin-bottom: 0px;\">Scheduler</h3>\n",
+       "            <p style=\"color: #9D9D9D; margin-bottom: 0px;\">Scheduler-4d707b44-9637-420c-872d-d1ef69c5db18</p>\n",
+       "            <table style=\"width: 100%; text-align: left;\">\n",
+       "                <tr>\n",
+       "                    <td style=\"text-align: left;\">\n",
+       "                        <strong>Comm:</strong> tcp://10.5.45.35:8786\n",
+       "                    </td>\n",
+       "                    <td style=\"text-align: left;\">\n",
+       "                        <strong>Workers:</strong> 2\n",
+       "                    </td>\n",
+       "                </tr>\n",
+       "                <tr>\n",
+       "                    <td style=\"text-align: left;\">\n",
+       "                        <strong>Dashboard:</strong> <a href=\"http://10.5.45.35:8787/status\" target=\"_blank\">http://10.5.45.35:8787/status</a>\n",
+       "                    </td>\n",
+       "                    <td style=\"text-align: left;\">\n",
+       "                        <strong>Total threads:</strong> 2\n",
+       "                    </td>\n",
+       "                </tr>\n",
+       "                <tr>\n",
+       "                    <td style=\"text-align: left;\">\n",
+       "                        <strong>Started:</strong> 1 minute ago\n",
+       "                    </td>\n",
+       "                    <td style=\"text-align: left;\">\n",
+       "                        <strong>Total memory:</strong> 14.00 GiB\n",
+       "                    </td>\n",
+       "                </tr>\n",
+       "            </table>\n",
+       "        </div>\n",
+       "    </div>\n",
+       "\n",
+       "    <details style=\"margin-left: 48px;\">\n",
+       "        <summary style=\"margin-bottom: 20px;\">\n",
+       "            <h3 style=\"display: inline;\">Workers</h3>\n",
+       "        </summary>\n",
+       "\n",
+       "        \n",
+       "        <div style=\"margin-bottom: 20px;\">\n",
+       "            <div style=\"width: 24px; height: 24px; background-color: #DBF5FF; border: 3px solid #4CC9FF; border-radius: 5px; position: absolute;\"> </div>\n",
+       "            <div style=\"margin-left: 48px;\">\n",
+       "            <details>\n",
+       "                <summary>\n",
+       "                    <h4 style=\"margin-bottom: 0px; display: inline;\">Worker: dask-eda6680f-worker-3802ecce</h4>\n",
+       "                </summary>\n",
+       "                <table style=\"width: 100%; text-align: left;\">\n",
+       "                    <tr>\n",
+       "                        <td style=\"text-align: left;\">\n",
+       "                            <strong>Comm: </strong> tcp://10.5.44.194:33113\n",
+       "                        </td>\n",
+       "                        <td style=\"text-align: left;\">\n",
+       "                            <strong>Total threads: </strong> 1\n",
+       "                        </td>\n",
+       "                    </tr>\n",
+       "                    <tr>\n",
+       "                        <td style=\"text-align: left;\">\n",
+       "                            <strong>Dashboard: </strong> <a href=\"http://10.5.44.194:37081/status\" target=\"_blank\">http://10.5.44.194:37081/status</a>\n",
+       "                        </td>\n",
+       "                        <td style=\"text-align: left;\">\n",
+       "                            <strong>Memory: </strong> 7.00 GiB\n",
+       "                        </td>\n",
+       "                    </tr>\n",
+       "                    <tr>\n",
+       "                        <td style=\"text-align: left;\">\n",
+       "                            <strong>Nanny: </strong> tcp://10.5.44.194:34827\n",
+       "                        </td>\n",
+       "                        <td style=\"text-align: left;\"></td>\n",
+       "                    </tr>\n",
+       "                    <tr>\n",
+       "                        <td colspan=\"2\" style=\"text-align: left;\">\n",
+       "                            <strong>Local directory: </strong> /tmp/dask-scratch-space/worker-cfusj0ml\n",
+       "                        </td>\n",
+       "                    </tr>\n",
+       "\n",
+       "                    \n",
+       "\n",
+       "                    \n",
+       "\n",
+       "                </table>\n",
+       "            </details>\n",
+       "            </div>\n",
+       "        </div>\n",
+       "        \n",
+       "        <div style=\"margin-bottom: 20px;\">\n",
+       "            <div style=\"width: 24px; height: 24px; background-color: #DBF5FF; border: 3px solid #4CC9FF; border-radius: 5px; position: absolute;\"> </div>\n",
+       "            <div style=\"margin-left: 48px;\">\n",
+       "            <details>\n",
+       "                <summary>\n",
+       "                    <h4 style=\"margin-bottom: 0px; display: inline;\">Worker: dask-eda6680f-worker-b8542521</h4>\n",
+       "                </summary>\n",
+       "                <table style=\"width: 100%; text-align: left;\">\n",
+       "                    <tr>\n",
+       "                        <td style=\"text-align: left;\">\n",
+       "                            <strong>Comm: </strong> tcp://10.5.46.251:38885\n",
+       "                        </td>\n",
+       "                        <td style=\"text-align: left;\">\n",
+       "                            <strong>Total threads: </strong> 1\n",
+       "                        </td>\n",
+       "                    </tr>\n",
+       "                    <tr>\n",
+       "                        <td style=\"text-align: left;\">\n",
+       "                            <strong>Dashboard: </strong> <a href=\"http://10.5.46.251:38323/status\" target=\"_blank\">http://10.5.46.251:38323/status</a>\n",
+       "                        </td>\n",
+       "                        <td style=\"text-align: left;\">\n",
+       "                            <strong>Memory: </strong> 7.00 GiB\n",
+       "                        </td>\n",
+       "                    </tr>\n",
+       "                    <tr>\n",
+       "                        <td style=\"text-align: left;\">\n",
+       "                            <strong>Nanny: </strong> tcp://10.5.46.251:41597\n",
+       "                        </td>\n",
+       "                        <td style=\"text-align: left;\"></td>\n",
+       "                    </tr>\n",
+       "                    <tr>\n",
+       "                        <td colspan=\"2\" style=\"text-align: left;\">\n",
+       "                            <strong>Local directory: </strong> /tmp/dask-scratch-space/worker-b_yovnqg\n",
+       "                        </td>\n",
+       "                    </tr>\n",
+       "\n",
+       "                    \n",
+       "\n",
+       "                    \n",
+       "\n",
+       "                </table>\n",
+       "            </details>\n",
+       "            </div>\n",
+       "        </div>\n",
+       "        \n",
+       "\n",
+       "    </details>\n",
+       "</div>\n",
+       "\n",
+       "        </details>\n",
+       "    </div>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "EC2Cluster(83565f96, 'tcp://10.5.45.35:8786', workers=2, threads=2, memory=14.00 GiB)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "cluster"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare DuckDB Query"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Below we create a function that will executes a DuckDB query. Each worker will run the same query, but receive a different paruqet file to query. This query filters by the bounding box of California, a temporal condition, and specifies a sort order. We limit the results to the first 2000, which is the upper limit for the current CMR API."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def ddb_worker_func(filename):\n",
+    "    df = duckdb.query(\n",
+    "        (\n",
+    "            f\"SELECT GranuleUR FROM read_parquet('{filename}') \"\n",
+    "            \"WHERE (-124.409202 <= MBREast AND -114.119061 >= MBRWest AND \"\n",
+    "            \"32.531669 <= MBRNorth AND 41.99954 >= MBRSouth) \"\n",
+    "            \"ORDER BY GranuleUR LIMIT 2000\"\n",
+    "        )\n",
+    "    ).df()\n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Provide the workers a list of input files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ddb_inputs = [\"/mnt/efs/17m_set1.parquet\", \"/mnt/efs/17m_set2.parquet\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run Query on Dask Cluster"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/ssm-user/.pyenv/versions/3.10.12/envs/jupyter3.10/lib/python3.10/site-packages/distributed/client.py:1612: VersionMismatchWarning: Mismatched versions found\n",
+      "\n",
+      "+---------+--------+-----------+---------+\n",
+      "| Package | Client | Scheduler | Workers |\n",
+      "+---------+--------+-----------+---------+\n",
+      "| lz4     | 4.4.3  | 4.3.3     | 4.3.3   |\n",
+      "| toolz   | 1.0.0  | 0.12.0    | 0.12.0  |\n",
+      "+---------+--------+-----------+---------+\n",
+      "  warnings.warn(version_module.VersionMismatchWarning(msg[0][\"warning\"]))\n"
+     ]
+    }
+   ],
+   "source": [
+    "client = cluster.get_client()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 8.86 ms, sys: 596 μs, total: 9.46 ms\n",
+      "Wall time: 1.94 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "the_future = client.map(ddb_worker_func, ddb_inputs)\n",
+    "results = client.gather(the_future)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run Same Query on Notebook Server\n",
+    "\n",
+    "For this run, the Jupyter server is the same instance type as the Dask workers: `c5.xlarge`. They have 4 vCPUs and 8 GB of RAM.\n",
+    "\n",
+    "Instead of two files, it will read the same data from a single file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "single_17m_file = \"~/efs/StartTime_17m.parquet\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 3.29 s, sys: 400 ms, total: 3.69 s\n",
+      "Wall time: 3.08 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "notebook_result = duckdb.query(\n",
+    "    (\n",
+    "        f\"SELECT GranuleUR FROM read_parquet('{single_17m_file}') \"\n",
+    "        \"WHERE (-124.409202 <= MBREast AND -114.119061 >= MBRWest AND \"\n",
+    "        \"32.531669 <= MBRNorth AND 41.99954 >= MBRSouth) \"\n",
+    "        \"ORDER BY GranuleUR LIMIT 2000\"\n",
+    "    )\n",
+    ").df()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Shut Down Cluster"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Terminated dask-eda6680f-worker-b8542521 (i-015d9a6692c3c8a47)\n",
+      "Terminated dask-eda6680f-worker-3802ecce (i-08a9996da6e441243)\n",
+      "Terminated dask-eda6680f-scheduler (i-0d190df1b812ce655)\n"
+     ]
+    }
+   ],
+   "source": [
+    "client.shutdown()\n",
+    "client.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/distributed/distributed_duckdb_example.ipynb
+++ b/distributed/distributed_duckdb_example.ipynb
@@ -342,8 +342,6 @@
    "outputs": [],
    "source": [
     "bootstrap_script = [\n",
-    "    \"mkdir -p /mnt/efs\",\n",
-    "    \"apt-get install nfs-common -y\",\n",
     "    f\"mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport {efs_id}.efs.us-east-1.amazonaws.com:/ /mnt/efs\",\n",
     "]"
    ]
@@ -376,7 +374,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -386,8 +384,8 @@
      "output_type": "stream",
      "text": [
       "Creating scheduler instance\n",
-      "Created instance i-0d190df1b812ce655 as dask-eda6680f-scheduler\n",
-      "Waiting for scheduler to run at 10.5.45.35:8786\n",
+      "Created instance i-009b530735c2eced3 as dask-2a2e0879-scheduler\n",
+      "Waiting for scheduler to run at 10.5.46.150:8786\n",
       "Scheduler is running\n",
       "Creating worker instance\n",
       "Creating worker instance\n"
@@ -405,14 +403,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Created instance i-015d9a6692c3c8a47 as dask-eda6680f-worker-b8542521\n",
-      "Created instance i-08a9996da6e441243 as dask-eda6680f-worker-3802ecce\n"
+      "Created instance i-0def0e897ddae1b97 as dask-2a2e0879-worker-eae73bf9\n",
+      "Created instance i-015e8fc4dea98a70c as dask-2a2e0879-worker-bf5d0c1f\n"
      ]
     }
    ],
    "source": [
     "cluster = EC2Cluster(\n",
     "    n_workers=2,\n",
+    "    # NGAP AL2023 AMI with default daskdev/dask Docker image already pulled\n",
+    "    ami=\"ami-0db6283751732f2ce\",\n",
+    "    # Default bootstrapping is for Debian-based images only\n",
+    "    bootstrap=False,\n",
     "    scheduler_instance_type=\"c5.xlarge\",\n",
     "    worker_instance_type=\"c5.xlarge\",\n",
     "    # One thread per worker ensures tasks get split across multiple workers\n",
@@ -433,7 +435,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -444,11 +446,11 @@
        "    </div>\n",
        "    <div style=\"margin-left: 48px;\">\n",
        "        <h3 style=\"margin-bottom: 0px; margin-top: 0px;\">EC2Cluster</h3>\n",
-       "        <p style=\"color: #9D9D9D; margin-bottom: 0px;\">83565f96</p>\n",
+       "        <p style=\"color: #9D9D9D; margin-bottom: 0px;\">37ffbd8b</p>\n",
        "        <table style=\"width: 100%; text-align: left;\">\n",
        "            <tr>\n",
        "                <td style=\"text-align: left;\">\n",
-       "                    <strong>Dashboard:</strong> <a href=\"http://10.5.45.35:8787/status\" target=\"_blank\">http://10.5.45.35:8787/status</a>\n",
+       "                    <strong>Dashboard:</strong> <a href=\"http://10.5.46.150:8787/status\" target=\"_blank\">http://10.5.46.150:8787/status</a>\n",
        "                </td>\n",
        "                <td style=\"text-align: left;\">\n",
        "                    <strong>Workers:</strong> 2\n",
@@ -475,11 +477,11 @@
        "        <div style=\"width: 24px; height: 24px; background-color: #FFF7E5; border: 3px solid #FF6132; border-radius: 5px; position: absolute;\"> </div>\n",
        "        <div style=\"margin-left: 48px;\">\n",
        "            <h3 style=\"margin-bottom: 0px;\">Scheduler</h3>\n",
-       "            <p style=\"color: #9D9D9D; margin-bottom: 0px;\">Scheduler-4d707b44-9637-420c-872d-d1ef69c5db18</p>\n",
+       "            <p style=\"color: #9D9D9D; margin-bottom: 0px;\">Scheduler-2a9676d1-f346-470e-ac6e-e0ffeb119626</p>\n",
        "            <table style=\"width: 100%; text-align: left;\">\n",
        "                <tr>\n",
        "                    <td style=\"text-align: left;\">\n",
-       "                        <strong>Comm:</strong> tcp://10.5.45.35:8786\n",
+       "                        <strong>Comm:</strong> tcp://10.5.46.150:8786\n",
        "                    </td>\n",
        "                    <td style=\"text-align: left;\">\n",
        "                        <strong>Workers:</strong> 2\n",
@@ -487,7 +489,7 @@
        "                </tr>\n",
        "                <tr>\n",
        "                    <td style=\"text-align: left;\">\n",
-       "                        <strong>Dashboard:</strong> <a href=\"http://10.5.45.35:8787/status\" target=\"_blank\">http://10.5.45.35:8787/status</a>\n",
+       "                        <strong>Dashboard:</strong> <a href=\"http://10.5.46.150:8787/status\" target=\"_blank\">http://10.5.46.150:8787/status</a>\n",
        "                    </td>\n",
        "                    <td style=\"text-align: left;\">\n",
        "                        <strong>Total threads:</strong> 2\n",
@@ -495,7 +497,7 @@
        "                </tr>\n",
        "                <tr>\n",
        "                    <td style=\"text-align: left;\">\n",
-       "                        <strong>Started:</strong> 1 minute ago\n",
+       "                        <strong>Started:</strong> 2 minutes ago\n",
        "                    </td>\n",
        "                    <td style=\"text-align: left;\">\n",
        "                        <strong>Total memory:</strong> 14.00 GiB\n",
@@ -516,12 +518,12 @@
        "            <div style=\"margin-left: 48px;\">\n",
        "            <details>\n",
        "                <summary>\n",
-       "                    <h4 style=\"margin-bottom: 0px; display: inline;\">Worker: dask-eda6680f-worker-3802ecce</h4>\n",
+       "                    <h4 style=\"margin-bottom: 0px; display: inline;\">Worker: dask-2a2e0879-worker-bf5d0c1f</h4>\n",
        "                </summary>\n",
        "                <table style=\"width: 100%; text-align: left;\">\n",
        "                    <tr>\n",
        "                        <td style=\"text-align: left;\">\n",
-       "                            <strong>Comm: </strong> tcp://10.5.44.194:33113\n",
+       "                            <strong>Comm: </strong> tcp://10.5.45.158:39761\n",
        "                        </td>\n",
        "                        <td style=\"text-align: left;\">\n",
        "                            <strong>Total threads: </strong> 1\n",
@@ -529,7 +531,7 @@
        "                    </tr>\n",
        "                    <tr>\n",
        "                        <td style=\"text-align: left;\">\n",
-       "                            <strong>Dashboard: </strong> <a href=\"http://10.5.44.194:37081/status\" target=\"_blank\">http://10.5.44.194:37081/status</a>\n",
+       "                            <strong>Dashboard: </strong> <a href=\"http://10.5.45.158:44827/status\" target=\"_blank\">http://10.5.45.158:44827/status</a>\n",
        "                        </td>\n",
        "                        <td style=\"text-align: left;\">\n",
        "                            <strong>Memory: </strong> 7.00 GiB\n",
@@ -537,13 +539,13 @@
        "                    </tr>\n",
        "                    <tr>\n",
        "                        <td style=\"text-align: left;\">\n",
-       "                            <strong>Nanny: </strong> tcp://10.5.44.194:34827\n",
+       "                            <strong>Nanny: </strong> tcp://10.5.45.158:38365\n",
        "                        </td>\n",
        "                        <td style=\"text-align: left;\"></td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
        "                        <td colspan=\"2\" style=\"text-align: left;\">\n",
-       "                            <strong>Local directory: </strong> /tmp/dask-scratch-space/worker-cfusj0ml\n",
+       "                            <strong>Local directory: </strong> /tmp/dask-scratch-space/worker-irjxmnsn\n",
        "                        </td>\n",
        "                    </tr>\n",
        "\n",
@@ -561,12 +563,12 @@
        "            <div style=\"margin-left: 48px;\">\n",
        "            <details>\n",
        "                <summary>\n",
-       "                    <h4 style=\"margin-bottom: 0px; display: inline;\">Worker: dask-eda6680f-worker-b8542521</h4>\n",
+       "                    <h4 style=\"margin-bottom: 0px; display: inline;\">Worker: dask-2a2e0879-worker-eae73bf9</h4>\n",
        "                </summary>\n",
        "                <table style=\"width: 100%; text-align: left;\">\n",
        "                    <tr>\n",
        "                        <td style=\"text-align: left;\">\n",
-       "                            <strong>Comm: </strong> tcp://10.5.46.251:38885\n",
+       "                            <strong>Comm: </strong> tcp://10.5.45.99:36921\n",
        "                        </td>\n",
        "                        <td style=\"text-align: left;\">\n",
        "                            <strong>Total threads: </strong> 1\n",
@@ -574,7 +576,7 @@
        "                    </tr>\n",
        "                    <tr>\n",
        "                        <td style=\"text-align: left;\">\n",
-       "                            <strong>Dashboard: </strong> <a href=\"http://10.5.46.251:38323/status\" target=\"_blank\">http://10.5.46.251:38323/status</a>\n",
+       "                            <strong>Dashboard: </strong> <a href=\"http://10.5.45.99:35695/status\" target=\"_blank\">http://10.5.45.99:35695/status</a>\n",
        "                        </td>\n",
        "                        <td style=\"text-align: left;\">\n",
        "                            <strong>Memory: </strong> 7.00 GiB\n",
@@ -582,13 +584,13 @@
        "                    </tr>\n",
        "                    <tr>\n",
        "                        <td style=\"text-align: left;\">\n",
-       "                            <strong>Nanny: </strong> tcp://10.5.46.251:41597\n",
+       "                            <strong>Nanny: </strong> tcp://10.5.45.99:41039\n",
        "                        </td>\n",
        "                        <td style=\"text-align: left;\"></td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
        "                        <td colspan=\"2\" style=\"text-align: left;\">\n",
-       "                            <strong>Local directory: </strong> /tmp/dask-scratch-space/worker-b_yovnqg\n",
+       "                            <strong>Local directory: </strong> /tmp/dask-scratch-space/worker-gti_7la5\n",
        "                        </td>\n",
        "                    </tr>\n",
        "\n",
@@ -610,7 +612,7 @@
        "</div>"
       ],
       "text/plain": [
-       "EC2Cluster(83565f96, 'tcp://10.5.45.35:8786', workers=2, threads=2, memory=14.00 GiB)"
+       "EC2Cluster(37ffbd8b, 'tcp://10.5.46.150:8786', workers=2, threads=2, memory=14.00 GiB)"
       ]
      },
      "metadata": {},
@@ -637,7 +639,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -662,7 +664,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -678,7 +680,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -703,15 +705,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 8.86 ms, sys: 596 μs, total: 9.46 ms\n",
-      "Wall time: 1.94 s\n"
+      "CPU times: user 10.7 ms, sys: 0 ns, total: 10.7 ms\n",
+      "Wall time: 1.92 s\n"
      ]
     }
    ],
@@ -734,7 +736,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -743,15 +745,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 3.29 s, sys: 400 ms, total: 3.69 s\n",
-      "Wall time: 3.08 s\n"
+      "CPU times: user 3.36 s, sys: 387 ms, total: 3.74 s\n",
+      "Wall time: 3.4 s\n"
      ]
     }
    ],
@@ -776,16 +778,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Terminated dask-eda6680f-worker-b8542521 (i-015d9a6692c3c8a47)\n",
-      "Terminated dask-eda6680f-worker-3802ecce (i-08a9996da6e441243)\n",
-      "Terminated dask-eda6680f-scheduler (i-0d190df1b812ce655)\n"
+      "Terminated dask-2a2e0879-worker-bf5d0c1f (i-015e8fc4dea98a70c)\n",
+      "Terminated dask-2a2e0879-worker-eae73bf9 (i-0def0e897ddae1b97)\n",
+      "Terminated dask-2a2e0879-scheduler (i-009b530735c2eced3)\n"
      ]
     }
    ],

--- a/distributed/query_AWS_for_packer.py
+++ b/distributed/query_AWS_for_packer.py
@@ -1,0 +1,83 @@
+import argparse
+import boto3
+from botocore.exceptions import ClientError
+import json
+
+
+# Sample function from AWS
+def get_AMI_owner():
+
+    secret_name = "NGAP_AMI_Account_ID"
+    region_name = "us-east-1"
+
+    session = boto3.session.Session()
+    client = session.client(service_name="secretsmanager", region_name=region_name)
+
+    try:
+        get_secret_value_response = client.get_secret_value(SecretId=secret_name)
+    except ClientError as e:
+        # For a list of exceptions thrown, see
+        # https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html
+        raise e
+
+    secret = get_secret_value_response["SecretString"]
+    return json.loads(secret)["AMI_Owner"]
+
+
+def get_vpc_id():
+    session = boto3.session.Session()
+    client = session.client("ec2")
+    # The intended account does not have a "default" VPC, so we locate it by index
+    vpc_id = client.describe_vpcs()["Vpcs"][0]["VpcId"]
+    return vpc_id
+
+
+def get_subnet_id(vpc_id, subnet_name):
+    session = boto3.session.Session()
+    client = session.client("ec2")
+
+    try:
+        # Describe subnets within the specified VPC
+        response = client.describe_subnets(
+            Filters=[
+                {"Name": "vpc-id", "Values": [vpc_id]},
+                {"Name": "tag:Name", "Values": [subnet_name]},
+            ]
+        )
+
+        if response["Subnets"]:
+            # Return the ID of the first matching subnet
+            return response["Subnets"][0]["SubnetId"]
+        else:
+            raise ValueError(
+                f"No subnet found with name '{subnet_name}' in VPC '{vpc_id}'"
+            )
+
+    except Exception as e:
+        print(f"An error occurred: {str(e)}")
+        return None
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Query AWS account information needed to run Packer."
+    )
+    parser.add_argument(
+        "function",
+        choices=["ami", "vpc", "subnet"],
+        help="Specify which information to retrieve",
+    )
+
+    args = parser.parse_args()
+
+    if args.function == "ami":
+        print(get_AMI_owner())
+    elif args.function == "vpc":
+        print(get_vpc_id())
+    elif args.function == "subnet":
+        vpc_id = get_vpc_id()
+        print(get_subnet_id(vpc_id, "Private application us-east-1c subnet"))
+
+
+if __name__ == "__main__":
+    main()

--- a/distributed/run_packer.sh
+++ b/distributed/run_packer.sh
@@ -1,0 +1,15 @@
+#! /bin/bash
+set -eux
+
+export AWS_PROFILE="cmr-sit"
+
+ownerID=$(python3 query_AWS_for_packer.py ami)
+vpcID=$(python3 query_AWS_for_packer.py vpc)
+subnetID=$(python3 query_AWS_for_packer.py subnet)
+packer init al2023-docker-dask.pkr.hcl
+packer validate al2023-docker-dask.pkr.hcl
+packer build -on-error=ask \
+  -var ami_owner_id="$ownerID" \
+  -var vpc_id="$vpcID" \
+  -var subnet_id="$subnetID" \
+  al2023-docker-dask.pkr.hcl


### PR DESCRIPTION
This workflow sets up a Dask cluster on EC2 to process data parallel DuckDB operations. The same query will be sent to every worker, with each worker querying different parquet files.

The workflow is described by README.md, which sets up the infrastructure, then through the cells of the `distributed/distributed_duckdb_example.ipynb` Jupyter notebook.